### PR TITLE
Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.a
 test
 branchtest
 stencil

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ all: libdbrew.a $(SUBDIRS)
 libdbrew.a: $(OBJS)
 	ar rcs libdbrew.a $(OBJS)
 
-tests:
-	cd tests && $(MAKE)
+test: libdbrew.a
+	$(MAKE) test -C tests
 
 examples:
 	cd examples && $(MAKE)
 
 clean:
 	rm -rf *~ *.o $(OBJS) libdbrew.a
-	cd tests && make clean
+	$(MAKE) clean -C tests
 	cd examples && make clean

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,11 +1,13 @@
-TESTPROGS = test branchtest op-tls
-CPPFLAGS=-I../include
-LDLIBS=-L.. -ldbrew
-CFLAGS=-O2
+.PHONY: all test store clean
 
-all: $(TESTPROGS)
+all:
+	./test.py --compile-only
 
-op-tls: op-tls.o test-parser.o
+test:
+	./test.py
+
+store:
+	./test.py --store
 
 clean:
-	rm -f *.o *~ $(TESTPROGS) test-op-inc test-op-pxor
+	rm -f *.o *~

--- a/tests/cases/op-inc.s
+++ b/tests/cases/op-inc.s
@@ -1,4 +1,4 @@
-        .text
+    .text
 	.globl	f1
 	.type	f1, @function
 f1:

--- a/tests/cases/op-inc.s.expect
+++ b/tests/cases/op-inc.s.expect
@@ -1,0 +1,27 @@
+Saving current emulator state: new with esID 0
+Capture 'H-call' (into 0x400996|0 + 0)
+Processing BB (400996|0)
+Emulation Static State (esID 0, call depth 0):
+  Registers: %rsp (R 0), %rdi (0x1)
+  Flags: (none)
+  Stack: (none)
+Decoding BB 400996 ...
+  0x400996:  89 f8                 mov     %edi,%eax
+  0x400998:  ff c0                 inc     %eax
+  0x40099a:  ff c8                 dec     %eax
+  0x40099c:  c3                    ret
+Emulate '0x400996: mov %edi,%eax'
+Emulate '0x400998: inc %eax'
+Emulate '0x40099a: dec %eax'
+Emulate '0x40099c: ret'
+Capture 'H-ret' (into 0x400996|0 + 1)
+Capture 'mov $0x1,%rax' (into 0x400996|0 + 2)
+Capture 'ret' (into 0x400996|0 + 3)
+OPT!!
+Generating code for BB 400996|0 (4 instructions)
+  I 0 : H-call                           7f8201df7000
+  I 1 : H-ret                            7f8201df7000
+  I 2 : mov     $0x1,%rax                7f8201df7000  48 c7 c0 01 00 00 00
+  I 3 : ret                              7f8201df7007  c3
+  0x7f8201df7012:  48 c7 c0 01 00 00 00  mov     $0x1,%rax
+  0x7f8201df7019:  c3                    ret

--- a/tests/test-parser.c
+++ b/tests/test-parser.c
@@ -1,20 +1,48 @@
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
 #include "dbrew.h"
 
 typedef int (*f1_t)(int);
 int f1(int);
 
-int main()
+int main(int argc, char** argv)
 {
     f1_t ff;
+
+    int parameter = 1;
+    bool debug = argc >= 2 && strcmp(argv[1], "--debug") == 0;
 
     Rewriter* r = brew_new();
     Rewriter* r2 = brew_new();
     dbrew_set_function(r, (uint64_t) f1);
-    dbrew_verbose(r, True, True, True);
-    dbrew_emulate_capture(r, 1);
+
+    // Only output DBB and new function but not intermediate steps as the stack
+    // pointer is different on each run. However, for debugging we want this
+    // information.
+    dbrew_verbose(r, True, debug ? True : False, True);
+
+    dbrew_config_staticpar(r, 0);
+    dbrew_emulate_capture(r, parameter);
+
     ff = (f1_t) dbrew_generated_code(r);
+
+    // Decode the newly generated function.
     DBB* dbb = dbrew_decode(r2, (uint64_t) ff);
     dbrew_print_decoded(dbb);
-    return ff(1);
-}
 
+    // // Ensure that the program actually works.
+    // int original = f1(parameter);
+    // int rewritten = ff(parameter);
+
+    // printf("!TST Original %d Rewritten %d\n", original, rewritten);
+
+    // if (rewritten != original)
+    // {
+    //     return 1;
+    // }
+
+    return 0;
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+from subprocess import call, Popen, PIPE
+import fnmatch
+import os
+import sys
+import difflib
+
+def compile(testCase):
+    print("==TEST Compiling", testCase)
+    outFile = testCase + ".o"
+    exitCode = call(["cc", "-o", outFile, testCase, "test-parser.c", "../libdbrew.a", "-I../include"])
+    if exitCode != 0:
+        print("==TEST ERROR while compiling, skipping")
+        raise Exception("Cannot compile")
+    return outFile
+
+def runTestCase(testCase):
+    outFile = compile(testCase)
+    print("==TEST Running", testCase)
+    proc = Popen("./" + outFile, stdout=PIPE, stderr=PIPE)
+    testResult = []
+
+    # This iterates through stdout and stderr in this order.
+    for stream in proc.communicate():
+        for out in stream.splitlines():
+            # Filter out debug output and remove trailing whitespaces for git
+            if len(out) >= 4 and out[:4] == "!DBG": continue
+            testResult.append(out.decode("utf-8").rstrip() + "\n")
+
+    if proc.returncode != 0:
+        print("==TEST CRASH", testCase, "return code", proc.returncode)
+        raise Exception("Test exited with non-zero code")
+    return testResult
+
+def store(testCase):
+    with open(testCase + ".expect", "w") as f:
+        f.writelines(runTestCase(testCase))
+
+def test(testCase):
+    with open(testCase + ".expect") as f:
+        comparison = f.readlines()
+    output = runTestCase(testCase)
+
+    if output != comparison:
+        print("==TEST FAILED  --  DIFF BELOW")
+        for line in difflib.context_diff(comparison, output): sys.stdout.write(line)
+        raise Exception("Output incorrect")
+
+actions = [
+    ("--test", test),
+    ("--store", store),
+    ("--compile-only", compile)
+]
+
+if __name__ == "__main__":
+    testFunction = test
+    files = None
+
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "--help":
+            print(sys.argv[0], "[--store,--compile-only]", "[.expect files]")
+            print("If no files are specified, all files in the cases folder are used.")
+            sys.exit(0)
+
+        for flag, function in actions:
+            if sys.argv[1] == flag:
+                testFunction = function
+                files = sys.argv[2:]
+                break
+
+        if files is None:
+            files = sys.argv[1:]
+
+    # In case there are no flags given or a flag is given but no file:
+    # Use all *.expect files in the cases directory.
+    if not files or len(files) == 0:
+        files = []
+        for root, dirnames, filenames in os.walk("cases"):
+            for filename in fnmatch.filter(filenames, "*.expect"):
+                files.append(os.path.join(root, filename))
+
+    # Remove .expect extension for the real filename
+    files = [file[:-7] for file in files]
+
+    failed = []
+    for testCase in files:
+        try:
+            testFunction(testCase)
+            print("==TEST PASSED")
+        except Exception as e:
+            print("==TEST FAILED", e)
+            failed.append(testCase)
+    if len(failed) > 0:
+        print("==TEST RESULT:", len(failed), "FAILED:", ", ".join(failed))
+        sys.exit(1)
+    else:
+        print("==TESTS PASSED")


### PR DESCRIPTION
Tests need to be added in the file test.py, the tests can be started with `make test`. Note that these currently fail as dynamic addresses are still involved in the output.

Lines are ignored if they are prefixed with `!DBG`.

If we want to include emulation steps in the debug output, we need to find a way to suppress all dynamic variables (e.g. stack pointer but also malloc or mmap). The output of emulation steps is currently suppressed for this reason.