### PR TITLE
Minor fix to test script

### DIFF
--- a/include/priv/common.h
+++ b/include/priv/common.h
@@ -25,6 +25,8 @@
 #include "buffers.h"
 #include "instr.h"
 
+#define debug(format, ...) printf("!DBG %s: " format "\n", __PRETTY_FUNCTION__, ##__VA_ARGS__)
+
 typedef struct _CBB CBB;
 typedef struct _DBB DBB;
 typedef struct _FunctionConfig FunctionConfig;

--- a/tests/cases/op-inc.s.expect
+++ b/tests/cases/op-inc.s.expect
@@ -19,9 +19,9 @@ Capture 'mov $0x1,%rax' (into test|0 + 2)
 Capture 'ret' (into test|0 + 3)
 OPT!!
 Generating code for BB (test|0) (4 instructions)
-  I 0 : H-call                           7f9bedd50000 
-  I 1 : H-ret                            7f9bedd50000 
-  I 2 : mov     $0x1,%rax                7f9bedd50000  48 c7 c0 01 00 00 00
-  I 3 : ret                              7f9bedd50007  c3
+  I 0 : H-call                           7fb71c7a3000 
+  I 1 : H-ret                            7fb71c7a3000 
+  I 2 : mov     $0x1,%rax                7fb71c7a3000  48 c7 c0 01 00 00 00
+  I 3 : ret                              7fb71c7a3007  c3
                  gen:  48 c7 c0 01 00 00 00  mov     $0x1,%rax
                gen+7:  c3                    ret    

--- a/tests/test.py
+++ b/tests/test.py
@@ -25,8 +25,9 @@ def runTestCase(testCase):
     for stream in proc.communicate():
         for out in stream.splitlines():
             # Filter out debug output and remove trailing whitespaces for git
+            out = out.decode("utf-8")
             if len(out) >= 4 and out[:4] == "!DBG": continue
-            testResult.append(out.decode("utf-8").rstrip() + "\n")
+            testResult.append(out + "\n")
 
     if proc.returncode != 0:
         print("==TEST CRASH", testCase, "return code", proc.returncode)


### PR DESCRIPTION
The test script now recognizes debug output correctly due to an encoding issue. Additionally, whitespaces are no longer stripped. See #1.