### PR TITLE
Add compilation command line to test entry point

### DIFF
--- a/tests/test-parser.c
+++ b/tests/test-parser.c
@@ -25,7 +25,7 @@ int main(int argc, char** argv)
     dbrew_verbose(r, True, debug ? True : False, True);
 
     dbrew_config_staticpar(r, 0);
-    dbrew_emulate_capture(r, parameter);
+    dbrew_emulate(r, parameter);
 
     ff = (f1_t) dbrew_generated_code(r);
 

--- a/tests/test-parser.c
+++ b/tests/test-parser.c
@@ -1,3 +1,4 @@
+//  COMPILE:cc -o %s %s test-parser.c ../libdbrew.a -I../include
 
 #include <stdio.h>
 #include <stdbool.h>

--- a/tests/test-parser.c
+++ b/tests/test-parser.c
@@ -26,9 +26,8 @@ int main(int argc, char** argv)
     dbrew_verbose(r, True, debug ? True : False, True);
 
     dbrew_config_staticpar(r, 0);
-    dbrew_emulate(r, parameter);
 
-    ff = (f1_t) dbrew_generated_code(r);
+    ff = (f1_t) dbrew_rewrite(r, parameter);
 
     // Decode the newly generated function.
     Rewriter* r2 = dbrew_new();

--- a/tests/test.py
+++ b/tests/test.py
@@ -9,7 +9,14 @@ import difflib
 def compile(testCase):
     print("==TEST Compiling", testCase)
     outFile = testCase + ".out"
-    exitCode = call(["cc", "-o", outFile, testCase, "test-parser.c", "../libdbrew.a", "-I../include"])
+
+    args = ["cc", "-o", outFile, testCase, "test-parser.c", "../libdbrew.a", "-I../include"]
+    with open("test-parser.c", "r") as f:
+        argLine = f.readline()
+        if argLine[:12] == "//  COMPILE:":
+            args = (argLine[12:] % (outFile, testCase)).split()
+
+    exitCode = call(args)
     if exitCode != 0:
         print("==TEST ERROR while compiling, skipping")
         raise Exception("Cannot compile")
@@ -37,6 +44,7 @@ def runTestCase(testCase):
 def store(testCase):
     with open(testCase + ".expect", "w") as f:
         f.writelines(runTestCase(testCase))
+        print("==TEST Stored", testCase)
 
 def test(testCase):
     with open(testCase + ".expect") as f:

--- a/tests/test.py
+++ b/tests/test.py
@@ -46,6 +46,9 @@ def store(testCase):
         f.writelines(runTestCase(testCase))
         print("==TEST Stored", testCase)
 
+def runAndPrint(testCase):
+    print("".join(runTestCase(testCase)))
+
 def test(testCase):
     with open(testCase + ".expect") as f:
         comparison = f.readlines()
@@ -58,6 +61,7 @@ def test(testCase):
 
 actions = [
     ("--test", test),
+    ("--run", runAndPrint),
     ("--store", store),
     ("--compile-only", compile)
 ]


### PR DESCRIPTION
This makes the code more reusable for different command lines and different paths.