### PR TITLE
Allow individual test cases to add compiler args

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -6,15 +6,20 @@ import os
 import sys
 import difflib
 
+def fetchCompilerArgs(file, outFile, testCase):
+    with open(file, "r") as f:
+        argLine = f.readline()
+        if argLine[:12] == "//  COMPILE:":
+            return (argLine[12:] % (outFile, testCase)).split()
+    return None
+
 def compile(testCase):
     print("==TEST Compiling", testCase)
     outFile = testCase + ".out"
 
-    args = ["cc", "-o", outFile, testCase, "test-parser.c", "../libdbrew.a", "-I../include"]
-    with open("test-parser.c", "r") as f:
-        argLine = f.readline()
-        if argLine[:12] == "//  COMPILE:":
-            args = (argLine[12:] % (outFile, testCase)).split()
+    args = fetchCompilerArgs(testCase, outFile, testCase)
+    if not args: args = fetchCompilerArgs("test-parser.c", outFile, testCase)
+    if not args: args = ["cc", "-o", outFile, testCase, "test-parser.c"]
 
     exitCode = call(args)
     if exitCode != 0:


### PR DESCRIPTION
Now, the compiler command line is fetched from the test case first. If the test case has no arguments, then the test-parser.c file is checked. If this file doesn't specify a compiler command line either, a default
call is used.

For example, a test case might require to be compiled with -O2 while other test cases require -O0.