### PR TITLE
Use REX.b for decoding immediate movs

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -937,7 +937,7 @@ DBB* dbrew_decode(Rewriter* r, uint64_t f)
         case 0xBC: case 0xBD: case 0xBE: case 0xBF:
             // MOV r32/64,imm32/64
             o1.reg = Reg_AX + (opc - 0xB8);
-            if (rex & REX_MASK_R) o1.reg += 8;
+            if (rex & REX_MASK_R || rex & REX_MASK_B) o1.reg += 8;
             if (rex & REX_MASK_W) {
                 vt = VT_64;
                 o1.type = OT_Reg64;

--- a/tests/cases/op-mov-r9d.s
+++ b/tests/cases/op-mov-r9d.s
@@ -1,0 +1,9 @@
+.intel_syntax noprefix
+    .text
+    .globl  f1
+    .type   f1, @function
+f1:
+    mov r9d, 0
+    mov rax, r9
+    ret
+.att_syntax noprefix

--- a/tests/cases/op-mov-r9d.s.expect
+++ b/tests/cases/op-mov-r9d.s.expect
@@ -1,0 +1,27 @@
+>>> Testcase known par = 1.
+Saving current emulator state: new with esID 0
+Capture 'H-call' (into test|0 + 0)
+Processing BB (test|0)
+Emulation Static State (esID 0, call depth 0):
+  Registers: %rsp (R 0), %rdi (0x1)
+  Flags: (none)
+  Stack: (none)
+Decoding BB test ...
+                test:  41 b9 00 00 00 00     mov     $0x0,%r9d
+              test+6:  4c 89 c8              mov     %r9,%rax
+              test+9:  c3                    ret    
+Emulate 'test: mov $0x0,%r9d'
+Emulate 'test+6: mov %r9,%rax'
+Emulate 'test+9: ret'
+Capture 'H-ret' (into test|0 + 1)
+Capture 'mov $0x0,%rax' (into test|0 + 2)
+Capture 'ret' (into test|0 + 3)
+OPT!!
+Generating code for BB test|0 (4 instructions)
+  I 0 : H-call                           (test|0)+0 
+  I 1 : H-ret                            (test|0)+0 
+  I 2 : mov     $0x0,%rax                (test|0)+0  48 31 c0
+  I 3 : ret                              (test|0)+3  c3
+BB gen (2 instructions):
+                 gen:  48 31 c0              xor     %rax,%rax
+               gen+3:  c3                    ret    


### PR DESCRIPTION
Previously, `mov r9d, 0` was decoded as `mov ecx, 0`. Please test and verify that this change doesn't break anything.

/cc @weidendo 