### PR TITLE
Fix decoding of push/pop with 16-bit operands

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -720,18 +720,22 @@ DBB* dbrew_decode(Rewriter* r, uint64_t f)
         case 0x54: case 0x55: case 0x56: case 0x57:
             // push
             reg = Reg_AX + (opc - 0x50);
+            vt = VT_64;
             if (hasRex && (rex & REX_MASK_B)) reg += 8;
+            if (has66) vt = VT_16;
             addUnaryOp(r, a, (uint64_t)(fp + off),
-                       IT_PUSH, getRegOp(VT_64, reg));
+                       IT_PUSH, getRegOp(vt, reg));
             break;
 
         case 0x58: case 0x59: case 0x5A: case 0x5B:
         case 0x5C: case 0x5D: case 0x5E: case 0x5F:
             // pop
             reg = Reg_AX + (opc - 0x58);
+            vt = VT_64;
             if (hasRex && (rex & REX_MASK_B)) reg += 8;
+            if (has66) vt = VT_16;
             addUnaryOp(r, a, (uint64_t)(fp + off),
-                       IT_POP, getRegOp(VT_64, reg));
+                       IT_POP, getRegOp(vt, reg));
             break;
 
         case 0x63:

--- a/src/instr.c
+++ b/src/instr.c
@@ -230,6 +230,7 @@ void copyOperand(Operand* dst, Operand* src)
         dst->val = src->val;
         break;
     case OT_Reg8:
+    case OT_Reg16:
     case OT_Reg32:
     case OT_Reg64:
     case OT_Reg128:

--- a/src/printer.c
+++ b/src/printer.c
@@ -31,6 +31,29 @@
 const char* regName(Reg r, OpType t)
 {
     switch(t) {
+    case OT_Reg16:
+        switch(r) {
+        case Reg_AX: return "ax";
+        case Reg_BX: return "bx";
+        case Reg_CX: return "cx";
+        case Reg_DX: return "dx";
+        case Reg_DI: return "di";
+        case Reg_SI: return "si";
+        case Reg_BP: return "bp";
+        case Reg_SP: return "sp";
+        case Reg_8:  return "r8w";
+        case Reg_9:  return "r9w";
+        case Reg_10: return "r10w";
+        case Reg_11: return "r11w";
+        case Reg_12: return "r12w";
+        case Reg_13: return "r13w";
+        case Reg_14: return "r14w";
+        case Reg_15: return "r15w";
+        case Reg_IP: return "ip";
+        default: assert(0);
+        }
+        break;
+
     case OT_Reg32:
         switch(r) {
         case Reg_AX: return "eax";
@@ -167,6 +190,7 @@ char* op2string(Operand* o, ValType t, FunctionConfig* fc)
     uint64_t val;
 
     switch(o->type) {
+    case OT_Reg16:
     case OT_Reg32:
     case OT_Reg64:
     case OT_Reg128:

--- a/tests/cases/decode/pop-word-ax.s
+++ b/tests/cases/decode/pop-word-ax.s
@@ -1,0 +1,8 @@
+//!driver = test-driver-decode.c
+.intel_syntax noprefix
+    .text
+    .globl  f1
+    .type   f1, @function
+f1:
+    pop ax
+    ret

--- a/tests/cases/decode/pop-word-ax.s.expect
+++ b/tests/cases/decode/pop-word-ax.s.expect
@@ -1,0 +1,3 @@
+BB f1 (2 instructions):
+                  f1:  66 58                 pop     %ax
+                f1+2:  c3                    ret    

--- a/tests/cases/decode/pop-word-r10w.s
+++ b/tests/cases/decode/pop-word-r10w.s
@@ -1,0 +1,8 @@
+//!driver = test-driver-decode.c
+.intel_syntax noprefix
+    .text
+    .globl  f1
+    .type   f1, @function
+f1:
+    pop r10w
+    ret

--- a/tests/cases/decode/pop-word-r10w.s.expect
+++ b/tests/cases/decode/pop-word-r10w.s.expect
@@ -1,0 +1,3 @@
+BB f1 (2 instructions):
+                  f1:  66 41 5a              pop     %r10w
+                f1+3:  c3                    ret    

--- a/tests/cases/decode/push-word-ax.s
+++ b/tests/cases/decode/push-word-ax.s
@@ -1,0 +1,8 @@
+//!driver = test-driver-decode.c
+.intel_syntax noprefix
+    .text
+    .globl  f1
+    .type   f1, @function
+f1:
+    push ax
+    ret

--- a/tests/cases/decode/push-word-ax.s.expect
+++ b/tests/cases/decode/push-word-ax.s.expect
@@ -1,0 +1,3 @@
+BB f1 (2 instructions):
+                  f1:  66 50                 push    %ax
+                f1+2:  c3                    ret    

--- a/tests/cases/decode/push-word-r10w.s
+++ b/tests/cases/decode/push-word-r10w.s
@@ -1,0 +1,8 @@
+//!driver = test-driver-decode.c
+.intel_syntax noprefix
+    .text
+    .globl  f1
+    .type   f1, @function
+f1:
+    push r10w
+    ret

--- a/tests/cases/decode/push-word-r10w.s.expect
+++ b/tests/cases/decode/push-word-r10w.s.expect
@@ -1,0 +1,3 @@
+BB f1 (2 instructions):
+                  f1:  66 41 52              push    %r10w
+                f1+3:  c3                    ret    


### PR DESCRIPTION
Now, instructions like `push ax` or `pop r15w` are decoded correctly and not as `push rax` or `pop r15`. Tests require #12, this is also the reason why the travis build fails.