### PR TITLE
Implement a new decoder

### DIFF
--- a/include/priv/instr-descriptors.h
+++ b/include/priv/instr-descriptors.h
@@ -1,0 +1,130 @@
+/**
+ * This file is part of DBrew, the dynamic binary rewriting library.
+ *
+ * (c) 2015-2016, Josef Weidendorfer <josef.weidendorfer@gmx.de>
+ *
+ * DBrew is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License (LGPL)
+ * as published by the Free Software Foundation, either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * DBrew is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DBrew.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* For now, decoded instructions in DBrew are x86-64 */
+
+#ifndef INSTR_DESCRIPTOR_H
+#define INSTR_DESCRIPTOR_H
+
+#include "instr.h"
+
+
+struct InstrDescriptor;
+
+typedef struct InstrDescriptor InstrDescriptor;
+
+typedef int(* DecodeHandler)(uint8_t* fp, Instr* instr, const InstrDescriptor* desc, int rex, OpSegOverride segment);
+// typedef int(* GenerateHandler)(uint8_t* fp, Instr* instr, const InstrDescriptor* desc);
+
+/**
+ * An instruction descriptor for an X86-64 instruction. This includes most
+ * general instructions and SSE instructions.
+ *
+ * Instructions with a VEX prefix require a different descriptor type, because
+ * the prefix includes the REX prefix, can imply opcodes and supports three
+ * register/memory operands as well as up to four operands in total.
+ **/
+struct InstrDescriptor {
+    /**
+     * \brief The encoding of the instruction
+     **/
+    OperandEncoding encoding;
+
+    /**
+     * \brief The number of opcodes
+     **/
+    uint8_t opcCount;
+
+    /**
+     * \brief The opcodes, -1 implies that this opcode is not used.
+     **/
+    int16_t opc[3];
+
+    /**
+     * \brief The prefix set, except the REX prefix
+     **/
+    PrefixSet prefixes;
+
+    /**
+     * \brief The types of the registers, one of RT_{G,V}{G,V}
+     **/
+    uint8_t regType;
+
+    /**
+     * \brief The value type of the first operand
+     *
+     * Further explanation:
+     *  - #VT_None means no override
+     *  - #VT_Implicit means #vti if the register is a general purpose register
+     *  - All other values mean an explicit override
+     **/
+    ValType vto1;
+
+    /**
+     * \brief The value type of the second operand
+     *
+     * See #vto1 for further details.
+     **/
+    ValType vto2;
+
+    /**
+     * \brief The value type of the instruction
+     *
+     * Further explanation:
+     *  - #VT_None means #VT_32 or #VT_64, depending on REX.W
+     *  - All other values mean an explicit override
+     *
+     * Special cases are handled in the #dbrew_decode_instruction function.
+     **/
+    ValType vti;
+
+    /**
+     * \brief The ModR/M digit for M, MC and MI encodings
+     **/
+    int8_t digit;
+
+    /**
+     * \brief The size of the immediate
+     **/
+    uint8_t immsize;
+
+    /**
+     * \brief Whether the instruction is conditional
+     **/
+    bool conditional;
+
+    /**
+     * \brief The instruction type
+     **/
+    InstrType type;
+
+    /**
+     * \brief Custom decode handler, used for #OE_None
+     **/
+    DecodeHandler decodeHandler;
+
+    // /**
+    //  * \brief Custom generate handler, used for #OE_None
+    //  **/
+    // GenerateHandler generateHandler;
+};
+
+extern const InstrDescriptor instrDescriptors[];
+
+#endif

--- a/include/priv/instr.h
+++ b/include/priv/instr.h
@@ -73,8 +73,10 @@ typedef enum _InstrType {
     // SSE Move
     IT_MOVSS, IT_MOVSD, IT_MOVUPS, IT_MOVUPD, IT_MOVAPS, IT_MOVAPD,
     IT_MOVDQU, IT_MOVDQA, IT_MOVLPD, IT_MOVLPS, IT_MOVHPD, IT_MOVHPS,
+
     // SSE Unpack
     IT_UNPCKLPS, IT_UNPCKLPD, IT_UNPCKHPS, IT_UNPCKHPD,
+
     // SSE FP arithmetic
     IT_ADDSS, IT_ADDSD, IT_ADDPS, IT_ADDPD,
     IT_SUBSS, IT_SUBSD, IT_SUBPS, IT_SUBPD,
@@ -91,6 +93,7 @@ typedef enum _InstrType {
     IT_HSUBPS, IT_HSUBPD,
     IT_RCPSS, IT_RCPPS,
     IT_RSQRTSS, IT_RSQRTPS,
+
     // SSE Integer operations
     IT_PCMPEQB, IT_PCMPEQW, IT_PCMPEQD,
     IT_PMINUB, IT_PMOVMSKB, IT_PXOR, IT_PADDQ,
@@ -138,13 +141,82 @@ typedef struct _Operand {
 typedef enum _OperandEncoding {
     OE_Invalid = 0,
     OE_None,
-    OE_MR,  // 2 operands, ModRM byte, dest is reg or memory
-    OE_RM,  // 2 operands, ModRM byte, src  is reg or memory
-    OE_RMI  // 3 operands, ModRM byte, src  is reg or memory, Immediate
+    /**
+     * \brief M encoding: 1 operand,  ModRM byte + digit
+     **/
+    OE_M,
+    /**
+     * \brief M1 encoding: 2 operands, ModRM byte + digit, Constant immediate 1
+     **/
+    OE_M1,
+    /**
+     * \brief MI encoding: 2 operands, ModRM byte + digit, Immediate
+     **/
+    OE_MI,
+    /**
+     * \brief MC encoding: 2 operands, ModRM byte + digit, Register RCX/ECX/CX/CL
+     **/
+    OE_MC,
+    /**
+     * \brief MR encoding: 2 operands, ModRM byte, dest is reg or memory
+     **/
+    OE_MR,
+    /**
+     * \brief MRI encoding: 3 operands, ModRM byte, dest is reg or memory, Immediate
+     **/
+    OE_MRI,
+    /**
+     * \brief MRC encoding: 3 operands, ModRM byte, dest is reg or memory, Implicit register CL
+     **/
+    OE_MRC,
+    /**
+     * \brief RM encoding: 2 operands, ModRM byte, src  is reg or memory
+     **/
+    OE_RM,
+    /**
+     * \brief RMI encoding: 3 operands, ModRM byte, src  is reg or memory, Immediate
+     **/
+    OE_RMI,
+    /**
+     * \brief RM0 encoding: 3 operands, ModRM byte, src  is reg or memory, Implicit register XMM0
+     **/
+    OE_RM0,
+    /**
+     * \brief O encoding: 1 operand,  opcode and register combined (may include rex prefix)
+     **/
+    OE_O,
+    /**
+     * \brief OI encoding: 2 operands, opcode and register combined (may include rex prefix), Immediate
+     **/
+    OE_OI,
+    /**
+     * \brief I encoding: 1 operand,  Immediate only
+     **/
+    OE_I,
+    /**
+     * \brief I encoding: 2 operands, Immediate, Register RAX/EAX/AX/AL
+     **/
+    OE_IA,
+    /**
+     * \brief D encoding: 1 operand,  Offset
+     **/
+    OE_D,
+    /**
+     * \brief FD encoding: 1 operand,  Move from Offset
+     **/
+    OE_FD,
+    /**
+     * \brief TD encoding: 1 operand,  Move to Offset
+     **/
+    OE_TD,
+    /**
+     * \brief NP encoding: 0 operands
+     **/
+    OE_NP,
 } OperandEncoding;
 
 typedef enum _PrefixSet {
-    PS_No = 0,
+    PS_None = 0,
     PS_66 = 2,
     PS_F2 = 4,
     PS_F3 = 8,
@@ -177,7 +249,6 @@ typedef struct _Instr {
     PrefixSet ptPSet;
     uint8_t ptOpc[3];
     OperandEncoding ptEnc;
-    StateChange ptSChange;
 
     ValType vtype; // without explicit operands or all operands of same type
     OperandForm form;
@@ -225,9 +296,7 @@ void initTernaryInstr(Instr* i, InstrType it,
                       Operand *o1, Operand *o2, Operand* o3);
 
 
-void attachPassthrough(Instr* i, PrefixSet set,
-                       OperandEncoding enc, StateChange sc,
-                       int b1, int b2, int b3);
+void attachPassthrough(Instr*, PrefixSet, OperandEncoding, int, int, int);
 
 
 #endif // INSTR_H

--- a/src/decode.c
+++ b/src/decode.c
@@ -19,12 +19,13 @@
 
 /* For now, decoder only does x86-64
  *
- * Opcode handlers are registered once and put into opcode tables.
+ * Opcodes are defined using instruction descriptors.
  *
  * FIXME:
  * - for 8bit regs, we do not support/assert on use of AH/BH/CH/DH
- * - difference between 64bit MMX and 64 SSE regs (?)
-*/
+ * - Eventually support MMX registers
+ * - Support VEX/EVEX prefix
+ */
 
 #include "decode.h"
 
@@ -37,146 +38,23 @@
 #include "printer.h"
 #include "engine.h"
 #include "error.h"
+#include "instr.h"
+#include "instr-descriptors.h"
 
-// decode context
-struct _DContext {
-    Rewriter* r;
 
-    // decoder position
-    DBB* dbb;
-    uint8_t* f;
-    int off;
-    uint64_t iaddr; // current instruction start address
-
-    // decoded prefixes
-    bool hasRex;
-    int rex; // REX prefix
-    PrefixSet ps; // detected prefix set
-    OpSegOverride segOv; // segment override prefix
-    ValType vt; // default operand type (derived from prefixes)
-
-    // decoded instruction parts
-    int opc1, opc2;
-
-    // temporaries for decode handler
-    Operand o1, o2, o3;
-    OperandEncoding oe;
-    int digit;
-    InstrType it;
-    Instr* ii;
-
-    // decoding result
-    bool exit;   // control flow change instruction detected
-    DecodeError error; // if not-null, an decoding error was detected
-};
-
-Instr* nextInstr(Rewriter* r, uint64_t a, int len)
+static
+const char*
+dbrew_stringify_bytes(uint8_t* instr, int count)
 {
-    Instr* i = r->decInstr + r->decInstrCount;
-    assert(r->decInstrCount < r->decInstrCapacity);
-    r->decInstrCount++;
+    if (count == 0)
+        return "";
 
-    i->addr = a;
-    i->len = len;
+    static char buf[46];
+    for (int i = 0, off = 0; i < count; i++)
+        off += snprintf(buf + off, sizeof(buf) - off, " %02x", instr[i]);
 
-    i->ptLen = 0;
-    i->vtype = VT_None;
-    i->form = OF_None;
-    i->dst.type = OT_None;
-    i->src.type = OT_None;
-    i->src2.type = OT_None;
-
-    return i;
+    return buf + 1;
 }
-
-Instr* addSimple(Rewriter* r, DContext* c, InstrType it)
-{
-    uint64_t len = (uint64_t)(c->f + c->off) - c->iaddr;
-    Instr* i = nextInstr(r, c->iaddr, len);
-    i->type = it;
-    i->form = OF_0;
-
-    return i;
-}
-
-Instr* addSimpleVType(Rewriter* r, DContext* c, InstrType it, ValType vt)
-{
-    uint64_t len = (uint64_t)(c->f + c->off) - c->iaddr;
-    Instr* i = nextInstr(r, c->iaddr, len);
-    i->type = it;
-    i->vtype = vt;
-    i->form = OF_0;
-
-    return i;
-}
-
-Instr* addUnaryOp(Rewriter* r, DContext* c, InstrType it, Operand* o)
-{
-    uint64_t len = (uint64_t)(c->f + c->off) - c->iaddr;
-    Instr* i = nextInstr(r, c->iaddr, len);
-    i->type = it;
-    i->form = OF_1;
-    copyOperand( &(i->dst), o);
-
-    return i;
-}
-
-Instr* addBinaryOp(Rewriter* r, DContext* c,
-                   InstrType it, ValType vt,
-                   Operand* o1, Operand* o2)
-{
-    if ((vt != VT_None) && (vt != VT_Implicit)) {
-        // if we specify an explicit value type, it must match destination
-        // 2nd operand does not have to match (e.g. conversion/mask extraction)
-        assert(vt == opValType(o1));
-    }
-
-    uint64_t len = (uint64_t)(c->f + c->off) - c->iaddr;
-    Instr* i = nextInstr(r, c->iaddr, len);
-    i->type = it;
-    i->form = OF_2;
-    i->vtype = vt;
-    copyOperand( &(i->dst), o1);
-    copyOperand( &(i->src), o2);
-
-    return i;
-}
-
-Instr* addTernaryOp(Rewriter* r, DContext* c,
-                    InstrType it, ValType vt,
-                    Operand* o1, Operand* o2, Operand* o3)
-{
-    if ((vt != VT_None) && (vt != VT_Implicit)) {
-        // if we specify an explicit value type, it must match destination
-        // 2nd operand does not have to match (e.g. conversion/mask extraction)
-        assert(vt == opValType(o1));
-    }
-
-    uint64_t len = (uint64_t)(c->f + c->off) - c->iaddr;
-    Instr* i = nextInstr(r, c->iaddr, len);
-    i->type = it;
-    i->form = OF_3;
-    i->vtype = vt;
-    copyOperand( &(i->dst), o1);
-    copyOperand( &(i->src), o2);
-    copyOperand( &(i->src2), o3);
-
-    return i;
-}
-
-
-// for parseModRM: register types (GP: general purpose integer, V: vector)
-typedef enum _RegTypes {
-    RT_None = 0,
-    RT_Op1V = 1,
-    RT_Op2V = 2,
-    RT_G = 0,        // 1 GP operand
-    RT_V = RT_Op1V,  // 1 vector operand
-    RT_GG = 0,       // 2 operands, both GP
-    RT_VG = RT_Op1V, // 2 ops, 1st V, 2nd GP
-    RT_GV = RT_Op2V, // 2 ops, 1st GP, 2nd V
-    RT_VV = RT_Op1V | RT_Op2V // 2 ops, both V
-} RegTypes;
 
 // Parse MR encoding (r/m,r: op1 is reg or memory operand, op2 is reg/digit),
 // or RM encoding (reverse op1/op2 when calling this function).
@@ -185,1931 +63,446 @@ typedef enum _RegTypes {
 // Fills o1/o2/digit
 // Increments offset in context according to parsed number of bytes
 static
-void parseModRM(DContext* cxt, ValType vt, RegTypes rt,
+int parseModRM(uint8_t* p,
+               int rex, OpSegOverride o1Seg, bool o1IsVec, bool o2IsVec,
                Operand* o1, Operand* o2, int* digit)
 {
-    int modrm, mod, rm, reg; // modRM byte
-    int sib, scale, idx, base; // SIB byte
-    int64_t disp;
-    Reg r;
     OpType ot;
-    int hasDisp8 = 0, hasDisp32 = 0;
+    int off = 0;
 
-    modrm = cxt->f[cxt->off++];
-    mod = (modrm & 192) >> 6;
-    reg = (modrm & 56) >> 3;
-    rm = modrm & 7;
+    // The ModR/M byte
+    int modrm = p[off++];
+    int mod = (modrm & 192) >> 6;
+    int reg = (modrm & 56) >> 3;
+    int rm = modrm & 7;
 
-    switch(vt) {
-    case VT_None: ot = (cxt->rex & REX_MASK_W) ? OT_Reg64 : OT_Reg32; break;
-    case VT_8:    ot = OT_Reg8; break;
-    case VT_16:   ot = OT_Reg16; break;
-    case VT_32:   ot = OT_Reg32; break;
-    case VT_64:   ot = OT_Reg64; break;
-    case VT_128:  ot = OT_Reg128; assert(rt & RT_Op2V); break;
-    case VT_256:  ot = OT_Reg256; assert(rt & RT_Op2V); break;
-    default: assert(0);
-    }
+    ot = rex & REX_MASK_W ? OT_Reg64 : OT_Reg32;
+
     // r part: reg or digit, give both back to caller
-    if (digit) *digit = reg;
-    if (o2) {
-        r = ((rt & RT_Op2V) ? Reg_X0 : Reg_AX) + reg;
-        if (cxt->rex & REX_MASK_R) r += 8;
+    if (digit)
+        *digit = reg;
+
+    if (o2)
+    {
         o2->type = ot;
-        o2->reg = r;
+        o2->reg = (o2IsVec ? Reg_X0 : Reg_AX) + reg + (rex & REX_MASK_R ? 8 : 0);
     }
 
-    if (mod == 3) {
+    if (mod == 3)
+    {
         // r, r
-        r = ((rt & RT_Op1V) ? Reg_X0 : Reg_AX) + rm;
-        if (cxt->rex & REX_MASK_B) r += 8;
         o1->type = ot;
-        o1->reg = r;
-        return;
+        o1->reg = (o1IsVec ? Reg_X0 : Reg_AX) + rm + (rex & REX_MASK_B ? 8 : 0);
+        return off;
     }
 
-    if (mod == 1) hasDisp8 = 1;
-    if (mod == 2) hasDisp32 = 1;
-    if ((mod == 0) && (rm == 5)) {
-        // mod 0 + rm 5: RIP relative
-        hasDisp32 = 1;
-    }
-
-    scale = 0;
-    if (rm == 4) {
-        // SIB
-        sib = cxt->f[cxt->off++];
+    // SIB byte
+    int scale = 0;
+    int idx = 0;
+    int base = 0;
+    if (rm == 4)
+    {
+        int sib = p[off++];
         scale = 1 << ((sib & 192) >> 6);
-        idx   = (sib & 56) >> 3;
-        base  = sib & 7;
-        if ((base == 5) && (mod == 0))
-            hasDisp32 = 1;
+        idx = (sib & 56) >> 3;
+        base = sib & 7;
     }
 
-    disp = 0;
-    if (hasDisp8) {
+    // Displacement
+    int64_t disp = 0;
+    if (mod == 1)
+    {
         // 8bit disp: sign extend
-        disp = *((signed char*) (cxt->f + cxt->off));
-        cxt->off++;
+        disp = *((int8_t*) (p + off));
+        off++;
     }
-    if (hasDisp32) {
-        disp = *((int32_t*) (cxt->f + cxt->off));
-        cxt->off += 4;
+    else if (mod == 2 || (mod == 0 && (rm == 5 || base == 5)))
+    {
+        // mod 0 + rm 5: RIP relative
+        // mod 0 + base 5: From SIB, implies rm == 4
+        disp = *((int32_t*) (p + off));
+        off += 4;
     }
 
-    switch(vt) {
-    case VT_None: ot = (cxt->rex & REX_MASK_W) ? OT_Ind64 : OT_Ind32; break;
-    case VT_8:    ot = OT_Ind8; break;
-    case VT_16:   ot = OT_Ind16; break;
-    case VT_32:   ot = OT_Ind32; break;
-    case VT_64:   ot = OT_Ind64; break;
-    case VT_128:  ot = OT_Ind128; assert(rt & RT_Op1V); break;
-    case VT_256:  ot = OT_Ind256; assert(rt & RT_Op1V); break;
-    default: assert(0);
-    }
-    o1->type = ot;
-    o1->seg = cxt->segOv;
+    o1->type = rex & REX_MASK_W ? OT_Ind64 : OT_Ind32;
+    o1->seg = o1Seg;
     o1->scale = scale;
     o1->val = (uint64_t) disp;
-    if (scale == 0) {
-        r = Reg_AX + rm;
-        if (cxt->rex & REX_MASK_B) r += 8;
-        o1->reg = ((mod == 0) && (rm == 5)) ? Reg_IP : r;
-        return;
+
+    if (scale == 0)
+    {
+        if (mod == 0 && rm == 5)
+            o1->reg = Reg_IP;
+        else
+            o1->reg = Reg_AX + rm + (rex & REX_MASK_B ? 8 : 0);
+
+        return off;
     }
 
-    if (cxt->rex & REX_MASK_X) idx += 8;
-    r = Reg_AX + idx;
-    o1->ireg = (idx == 4) ? Reg_None : r;
-
-
-    if (cxt->rex & REX_MASK_B) base += 8;
-    r = Reg_AX + base;
-    o1->reg = ((base == 5) && (mod == 0)) ? Reg_None : r;
-
-    // no need to use SIB if index register not used
-    if (o1->ireg == Reg_None) o1->scale = 0;
-}
-
-// parse immediate value at current decode context into operand <o>
-static
-void parseImm(DContext* c, ValType vt, Operand* o, bool realImm64)
-{
-    switch(vt) {
-    case VT_8:
-        o->type = OT_Imm8;
-        o->val = *(c->f + c->off);
-        c->off++;
-        break;
-    case VT_16:
-        o->type = OT_Imm16;
-        o->val = *(uint16_t*)(c->f + c->off);
-        c->off += 2;
-        break;
-    case VT_32:
-        o->type = OT_Imm32;
-        o->val = *(uint32_t*)(c->f + c->off);
-        c->off += 4;
-        break;
-    case VT_64:
-        o->type = OT_Imm64;
-        if (realImm64) {
-            // operand is real 64 immediate
-            o->val = *(uint64_t*)(c->f + c->off);
-            c->off += 8;
-        }
-        else {
-            // operand is sign-extended from 32bit
-            o->val = (int64_t)(*(int32_t*)(c->f + c->off));
-            c->off += 4;
-        }
-        break;
-    default:
-        assert(0);
+    if (idx == 4)
+    {
+        // no need to use SIB if index register not used
+        o1->scale = 0;
+        o1->ireg = Reg_None;
     }
-}
+    else
+        o1->ireg = Reg_AX + idx + (rex & REX_MASK_X ? 8 : 0);
 
-static
-void initDContext(DContext* cxt, Rewriter* r, DBB* dbb)
-{
-    cxt->r = r;
-    cxt->dbb = dbb;
-    cxt->f = (uint8_t*) dbb->addr;
-    cxt->off = 0;
+    if (base == 5 && mod == 0)
+        o1->reg = Reg_None;
+    else
+        o1->reg = Reg_AX + base + (rex & REX_MASK_B ? 8 : 0);
 
-    cxt->exit = false;
-    setErrorNone((Error*) &(cxt->error));
-}
-
-// possible prefixes:
-// - REX: bits extended 64bit architecture
-// - 2E : cs-segment override or branch not taken hint (Jcc)
-// - ...
-static
-void decodePrefixes(DContext* cxt)
-{
-    // starts a new instruction
-    cxt->iaddr = (uint64_t)(cxt->f + cxt->off);
-    cxt->rex = 0;
-    cxt->hasRex = false;
-    cxt->segOv = OSO_None;
-    cxt->ps = PS_No;
-
-    cxt->opc1 = -1;
-    cxt->opc2 = -1;
-    cxt->exit = false;
-    assert(cxt->error.e.et == ET_NoError);
-
-    while(1) {
-        uint8_t b = cxt->f[cxt->off];
-        if ((b >= 0x40) && (b <= 0x4F)) {
-            cxt->rex = b & 15;
-            cxt->hasRex = true;
-        }
-        else if (b == 0xF2) cxt->ps |= PS_F2;
-        else if (b == 0xF3) cxt->ps |= PS_F3;
-        else if (b == 0x66) cxt->ps |= PS_66;
-        else if (b == 0x64) cxt->segOv = OSO_UseFS;
-        else if (b == 0x65) cxt->segOv = OSO_UseGS;
-        else if (b == 0x2E) cxt->ps |= PS_2E;
-        else {
-            // no further prefixes
-            break;
-        }
-        cxt->off++;
-    }
+    return off;
 }
 
 /**
- * Decoding handlers called via opcode tables
+ * Decode one instruction at the given function pointer.
  *
- * For each entry in an opcode table, up to 3 handlers can be called.
- */
-typedef void (*DecHandler)(DContext*);
-
-typedef enum _OpcType {
-    OT_Invalid,
-    OT_Single,  // opcode for 1 instructions
-    OT_Four,    // opcode for 4 instr (no prefix, 66, F3, F2)
-    OT_Group    // opcode for 8 instructions
-} OpcType;
-
-typedef struct _OpcInfo OpcInfo;
-struct _OpcInfo {
-    OpcType t;
-    int opc;
-    int eStart;  // offset into opcEntry table
-};
-
-typedef struct _OpcEntry OpcEntry;
-struct _OpcEntry {
-    DecHandler h1, h2, h3;
-    ValType vt;    // default or specific operand type?
-    InstrType it;  // preset for it in DContext
-};
-
-static OpcInfo opcTable[256];
-static OpcInfo opcTable0F[256];
-
-#define OPCENTRY_SIZE 1000
-static OpcEntry opcEntry[OPCENTRY_SIZE];
-
-// set type for opcode, allocate space in opcEntry table
-// if type already set, only check
-// returns start offset into opcEntry table
-static
-int setOpcInfo(int opc, OpcType t)
+ * \private
+ *
+ * \param fp The byte stream
+ * \param r The rewriter
+ * \param isTerminator Set to true when the instruction terminates a basic block
+ * \returns The number of bytes consumed, or -1 if there was an error while
+ * decoding the instruction.
+ **/
+static int
+dbrew_decode_instruction(uint8_t* fp, Rewriter* r, bool* isTerminator)
 {
-    static int used = 0; // use count of opcEntry table
-    OpcInfo* oi;
-
-    if ((opc>=0) && (opc<=0xFF)) {
-        assert(opc != 0x0F);
-        oi = &(opcTable[opc]);
-    }
-    else if ((opc>=0x0F00) && (opc<=0x0FFF)) {
-        oi = &(opcTable0F[opc - 0x0F00]);
-    }
-    else assert(0);
-
-    if (oi->t == OT_Invalid) {
-        // opcode not seen yet
-        oi->t = t;
-        oi->opc = opc;
-        oi->eStart = used;
-        switch(t) {
-        case OT_Single: used += 1; break;
-        case OT_Four:   used += 4; break;
-        case OT_Group:  used += 8; break;
-        default: assert(0);
-        }
-        assert(used <= OPCENTRY_SIZE);
-        for(int i = oi->eStart; i < used; i++)
-            opcEntry[i].h1 = 0;
-    }
-    else
-        assert(oi->t == t);
-
-    return oi->eStart;
-}
-
-static
-OpcEntry* getOpcEntry(int opc, OpcType t, int off)
-{
-    int count;
-    int start = setOpcInfo(opc, t);
-    switch(t) {
-    case OT_Single: count = 1; break;
-    case OT_Four:   count = 4; break;
-    case OT_Group:  count = 8; break;
-    default: assert(0);
-    }
-    assert((off >= 0) && (off<count));
-    return &(opcEntry[start+off]);
-}
-
-static
-void initOpcEntry(OpcEntry* e, InstrType it, ValType vt,
-                  DecHandler h1, DecHandler h2, DecHandler h3)
-{
-    e->h1 = h1;
-    e->h2 = h2;
-    e->h3 = h3;
-    e->vt = vt;
-    e->it = it;
-}
-
-
-static
-OpcEntry* setOpc(int opc, InstrType it, ValType vt,
-                 DecHandler h1, DecHandler h2, DecHandler h3)
-{
-    OpcEntry* e = getOpcEntry(opc, OT_Single, 0);
-    initOpcEntry(e, it, vt, h1, h2, h3);
-    return e;
-}
-
-// set handler for opcodes with instruction depending on 66/F2/f3 prefix
-static
-OpcEntry* setOpcP(int opc, PrefixSet ps,
-                  InstrType it, ValType vt,
-                  DecHandler h1, DecHandler h2, DecHandler h3)
-{
-    int off;
-    switch(ps) {
-    case PS_No: off = 0; break;
-    case PS_66:   off = 1; break;
-    case PS_F3:   off = 2; break;
-    case PS_F2:   off = 3; break;
-    default: assert(0);
-    }
-
-    OpcEntry* e = getOpcEntry(opc, OT_Four, off);
-    initOpcEntry(e, it, vt, h1, h2, h3);
-    return e;
-}
-
-// set specific handler for opcode with given prefix
-static
-OpcEntry* setOpcPH(int opc, PrefixSet ps, DecHandler h)
-{
-    return setOpcP(opc, ps, IT_None, VT_Def, h, 0, 0);
-}
-
-// set specific handler for given opcode
-static
-OpcEntry* setOpcH(int opc, DecHandler h)
-{
-    return setOpc(opc, IT_None, VT_Def, h, 0, 0);
-}
-
-// set handler for opcodes using a sub-opcode group
-// use the digit sub-opcode for <off>
-static
-OpcEntry* setOpcG(int opc, int digit,
-                  InstrType it, ValType vt,
-                  DecHandler h1, DecHandler h2, DecHandler h3)
-{
-    OpcEntry* e = getOpcEntry(opc, OT_Group, digit);
-    initOpcEntry(e, it, vt, h1, h2, h3);
-    return e;
-}
-
-// set specific handler for opcode with sub-opcode digit
-static
-OpcEntry* setOpcGH(int opc, int digit, DecHandler h)
-{
-    return setOpcG(opc, digit, IT_None, VT_Def, h, 0, 0);
-}
-
-static
-void markDecodeError(DContext* c, int opc)
-{
-    static char buf[64];
-
-    sprintf(buf, "invalid opcode %d", opc);
-    addSimple(c->r, c, IT_Invalid);
-    setDecodeError(&(c->error), c->r, buf, ET_BadOpcode, 0, c->off);
-}
-
-
-static
-void processOpc(OpcInfo* oi, DContext* c)
-{
-    OpcEntry* e;
-    int off = 0;
-
-    switch(oi->t) {
-    case OT_Invalid:
-        // invalid opcode
-        markDecodeError(c, 0);
-        return;
-    case OT_Single:
-        break;
-    case OT_Four:
-        switch(c->ps) {
-        case PS_No: off = 0; break;
-        case PS_66:   off = 1; break;
-        case PS_F3:   off = 2; break;
-        case PS_F2:   off = 3; break;
-        default: assert(0);
-        }
-        break;
-    case OT_Group:
-        off = (c->f[c->off] & 56) >> 3; // digit
-        break;
-    default: assert(0);
-    }
-    e = &(opcEntry[oi->eStart+off]);
-
-    c->it = e->it;
-    if (e->vt == VT_Def) {
-        // derive type from prefixes
-        c->vt = (c->rex & REX_MASK_W) ? VT_64 : VT_32;
-        if (c->ps & PS_66) c->vt = VT_16;
-    }
-    else
-        c->vt = e->vt;
-
-    assert(e->h1 != 0);
-    (e->h1)(c);
-    if (e->h2 == 0) return;
-    (e->h2)(c);
-    if (e->h3 == 0) return;
-    (e->h3)(c);
-}
-
-// operand processing handlers
-
-// put M of RM encoding in op 1
-//static void parseM1(DContext* c) { parseModRM(c, c->vt, RT_G, &c->o1, 0, 0); }
-
-
-// RM encoding for 2 GP registers
-static void parseRM(DContext* c)
-{
-    parseModRM(c, c->vt, RT_GG, &c->o2, &c->o1, 0);
-}
-
-// MR encoding for 2 GP registers
-static void parseMR(DContext* c)
-{
-    parseModRM(c, c->vt, RT_GG, &c->o1, &c->o2, 0);
-}
-
-// RM encoding for 2 vector registers, remember encoding for pass-through
-static void parseRMVV(DContext* c)
-{
-    parseModRM(c, c->vt, RT_VV, &c->o2, &c->o1, 0);
-    c->oe = OE_RM;
-}
-
-// MR encoding for 2 vector registers, remember encoding for pass-through
-static void parseMRVV(DContext* c)
-{
-    parseModRM(c, c->vt, RT_VV, &c->o1, &c->o2, 0);
-    c->oe = OE_MR;
-}
-
-
-// parse immediate into op 1 (for 64bit with imm32 signed extension)
-static void parseI1(DContext* c)
-{
-    parseImm(c, c->vt, &c->o1, false);
-}
-
-// parse immediate into op 2 (for 64bit with imm32 signed extension)
-static void parseI2(DContext* c)
-{
-    parseImm(c, c->vt, &c->o2, false);
-}
-
-// parse immediate into op 2 (for 64bit with imm32 signed extension)
-static void parseI3(DContext* c)
-{
-    parseImm(c, c->vt, &c->o3, false);
-}
-
-// parse immediate 8bit into op 3, signed extend to operand type
-static void parseI3_8se(DContext* c)
-{
-    parseImm(c, VT_8, &c->o3, false);
-    // sign-extend op3 to required type: 8->64 works for all
-    c->o3.val = (int64_t)(int8_t)c->o3.val;
-    c->o3.type = getImmOpType(c->vt);
-}
-
-// set op1 as al/ax/eax/rax register
-static void setO1RegA(DContext* c)
-{
-    setRegOp(&c->o1, c->vt, Reg_AX);
-}
-
-// M in op 1, Imm in op 2 (64bit with imm32 signed extension)
-static void parseMI(DContext* c)
-{
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, 0);
-    parseImm(c, c->vt, &c->o2, false);
-}
-
-// M in op 1, Imm in op 2 (64bit with imm32 signed extension)
-static void parseMI_8se(DContext* c)
-{
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, 0);
-    parseImm(c, VT_8, &c->o2, false);
-    // sign-extend op2 to required type: 8->64 works for all
-    c->o2.val = (int64_t)(int8_t)c->o2.val;
-    c->o2.type = getImmOpType(c->vt);
-}
-
-// instruction append handlers
-
-// append simple instruction without operands
-static void addSInstr(DContext* c)
-{
-    c->ii = addSimple(c->r, c, c->it);
-}
-
-// append unary instruction
-static void addUInstr(DContext* c)
-{
-    c->ii = addUnaryOp(c->r, c, c->it, &c->o1);
-}
-
-// append binary instruction
-static void addBInstr(DContext* c)
-{
-    c->ii = addBinaryOp(c->r, c, c->it, c->vt, &c->o1, &c->o2);
-}
-
-// append binary instruction with implicit type (depends on instr name)
-static void addBInsImp(DContext* c)
-{
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-}
-
-
-// append ternary instruction
-static void addTInstr(DContext* c)
-{
-    c->ii = addTernaryOp(c->r, c, c->it, c->vt, &c->o1, &c->o2, &c->o3);
-}
-
-// request exit from decoder
-static void reqExit(DContext* c)
-{
-    c->exit = true;
-}
-
-// attach pass-through information
-static void attach(DContext* c)
-{
-    attachPassthrough(c->ii, c->ps, c->oe, SC_None,
-                      c->opc1, c->opc2, -1);
-}
-
-// opcode-specific decode handlers
-
-
-//
-// handlers for multi-byte opcodes starting with 0x0F
-//
-
-
-static
-void decode0F_12(DContext* c)
-{
-    switch(c->ps) {
-    case PS_66:
-        // movlpd xmm,m64 (RM) - mov DP FP from m64 to low quadword of xmm
-        c->it = IT_MOVLPD; break;
-    case PS_No:
-        // movlps xmm,m64 (RM) - mov 2SP FP from m64 to low quadword of xmm
-        c->it = IT_MOVLPS; break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    parseModRM(c, VT_64, RT_VV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_RM, SC_None, 0x0F, 0x12, -1);
-}
-
-static
-void decode0F_13(DContext* c)
-{
-    switch(c->ps) {
-    case PS_66:
-        // movlpd m64,xmm (MR) - mov DP FP from low quadword of xmm to m64
-        c->it = IT_MOVLPD; break;
-    case PS_No:
-        // movlps m64,xmm (MR) - mov 2SP FP from low quadword of xmm to m64
-        c->it = IT_MOVLPS; break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    parseModRM(c, VT_64, RT_VV, &c->o1, &c->o2, 0);
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_MR, SC_None, 0x0F, 0x13, -1);
-}
-
-static
-void decode0F_14(DContext* c)
-{
-    switch(c->ps) {
-    case PS_66:   // unpcklpd xmm1,xmm2/m128 (RM)
-        c->it = IT_UNPCKLPD; break;
-    case PS_No: // unpcklps xmm1,xmm2/m128 (RM)
-        c->it = IT_UNPCKLPS; break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    parseModRM(c, VT_128, RT_VV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_RM, SC_None, 0x0F, 0x14, -1);
-}
-
-static
-void decode0F_15(DContext* c)
-{
-    switch(c->ps) {
-    case PS_66:   // unpckhpd xmm1,xmm2/m128 (RM)
-        c->it = IT_UNPCKHPD; break;
-    case PS_No: // unpckhps xmm1,xmm2/m128 (RM)
-        c->it = IT_UNPCKHPS; break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    parseModRM(c, VT_128, RT_VV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_RM, SC_None, 0x0F, 0x15, -1);
-}
-
-static
-void decode0F_16(DContext* c)
-{
-    switch(c->ps) {
-    case PS_66:
-        // movhpd xmm,m64 (RM) - mov DP FP from m64 to high quadword of xmm
-        c->it = IT_MOVHPD; break;
-    case PS_No:
-        // movhps xmm,m64 (RM) - mov 2SP FP from m64 to high quadword of xmm
-        c->it = IT_MOVHPS; break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    parseModRM(c, VT_128, RT_VV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_RM, SC_None, 0x0F, 0x16, -1);
-}
-
-static
-void decode0F_17(DContext* c)
-{
-    switch(c->ps) {
-    case PS_66:
-        // movhpd m64,xmm (MR) - mov DP FP from high quadword of xmm to m64
-        c->it = IT_MOVHPD; break;
-    case PS_No:
-        // movhps m64,xmm (MR) - mov 2SP FP from high quadword of xmm to m64
-        c->it = IT_MOVHPS; break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    parseModRM(c, VT_64, RT_VV, &c->o1, &c->o2, 0);
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_MR, SC_None, 0x0F, 0x17, -1);
-}
-
-static
-void decode0F_1F(DContext* c)
-{
+    PrefixSet ps = PS_None;
+    OpSegOverride segmentOverride = OSO_None;
+    Operand o1;
+    Operand o2;
+    Operand o3;
+    Instr* instr;
+    uint64_t off = 0;
+    int rex = 0;
     int digit;
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &digit);
-    switch(digit) {
-    case 0:
-        // 0F 1F /0: nop r/m 16/32
-        assert((c->vt == VT_16) || (c->vt == VT_32));
-        addUnaryOp(c->r, c, IT_NOP, &c->o1);
-        break;
+    int immsize;
 
-    default:
-        addSimple(c->r, c, IT_Invalid);
-        break;
-    }
-}
-
-static
-void decode0F_28(DContext* c)
-{
-    switch(c->ps) {
-    case PS_No: // movaps xmm1,xmm2/m128 (RM)
-        c->vt = VT_128; c->it = IT_MOVAPS; break;
-    case PS_66:   // movapd xmm1,xmm2/m128 (RM)
-        c->vt = VT_128; c->it = IT_MOVAPD; break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    parseModRM(c, c->vt, RT_VV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_RM, SC_None, 0x0F, 0x28, -1);
-}
-
-static
-void decode0F_29(DContext* c)
-{
-    switch(c->ps) {
-    case PS_No: // movaps xmm2/m128,xmm1 (MR)
-        c->vt = VT_128; c->it = IT_MOVAPS; break;
-    case PS_66:   // movapd xmm2/m128,xmm1 (MR)
-        c->vt = VT_128; c->it = IT_MOVAPD; break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    parseModRM(c, c->vt, RT_VV, &c->o1, &c->o2, 0);
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_RM, SC_None, 0x0F, 0x29, -1);
-}
-
-static
-void decode0F_2E(DContext* c)
-{
-    assert(c->ps & PS_66);
-    // ucomisd xmm1,xmm2/m64 (RM)
-    parseModRM(c, VT_64, RT_VV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, IT_UCOMISD, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, PS_66, OE_RM, SC_None, 0x0F, 0x2E, -1);
-}
-
-// 0x40: cmovo   r,r/m 16/32/64
-// 0x41: cmovno  r,r/m 16/32/64
-// 0x42: cmovc   r,r/m 16/32/64
-// 0x43: cmovnc  r,r/m 16/32/64
-// 0x44: cmovz   r,r/m 16/32/64
-// 0x45: cmovnz  r,r/m 16/32/64
-// 0x46: cmovbe  r,r/m 16/32/64
-// 0x47: cmova   r,r/m 16/32/64
-// 0x48: cmovs   r,r/m 16/32/64
-// 0x49: cmovns  r,r/m 16/32/64
-// 0x4A: cmovp   r,r/m 16/32/64
-// 0x4B: cmovnp  r,r/m 16/32/64
-// 0x4C: cmovl   r,r/m 16/32/64
-// 0x4D: cmovge  r,r/m 16/32/64
-// 0x4E: cmovle  r,r/m 16/32/64
-// 0x4F: cmovg   r,r/m 16/32/64
-static
-void decode0F_40(DContext* c)
-{
-    switch (c->opc2) {
-    case 0x40: c->it = IT_CMOVO; break;
-    case 0x41: c->it = IT_CMOVNO; break;
-    case 0x42: c->it = IT_CMOVC; break;
-    case 0x43: c->it = IT_CMOVNC; break;
-    case 0x44: c->it = IT_CMOVZ; break;
-    case 0x45: c->it = IT_CMOVNZ; break;
-    case 0x46: c->it = IT_CMOVBE; break;
-    case 0x47: c->it = IT_CMOVA; break;
-    case 0x48: c->it = IT_CMOVS; break;
-    case 0x49: c->it = IT_CMOVNS; break;
-    case 0x4A: c->it = IT_CMOVP; break;
-    case 0x4B: c->it = IT_CMOVNP; break;
-    case 0x4C: c->it = IT_CMOVL; break;
-    case 0x4D: c->it = IT_CMOVGE; break;
-    case 0x4E: c->it = IT_CMOVLE; break;
-    case 0x4F: c->it = IT_CMOVG; break;
-    default: assert(0);
-    }
-    parseModRM(c, c->vt, RT_GG, &c->o2, &c->o1, 0);
-    addBinaryOp(c->r, c, c->it, c->vt, &c->o1, &c->o2);
-}
-
-static
-void decode0F_6E_P66(DContext* c)
-{
-    // movd/q xmm,r/m 32/64 (RM)
-    c->vt = (c->rex & REX_MASK_W) ? VT_64 : VT_32;
-    c->it = (c->rex & REX_MASK_W) ? IT_MOVQ : IT_MOVD;
-    parseModRM(c, c->vt, RT_GV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    if (c->rex & REX_MASK_W) c->ps |= PS_REXW; // pass-through REX_W setting
-    attachPassthrough(c->ii, c->ps, OE_RM, SC_dstDyn, 0x0F, 0x6E, -1);
-}
-
-
-static
-void decode0F_74(DContext* c)
-{
-    // pcmpeqb mm,mm/m 64/128 (RM): compare packed bytes
-    switch(c->ps) {
-    case PS_66: c->vt = VT_128; break;
-    case PS_No: c->vt = VT_64; break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    parseModRM(c, c->vt, RT_VV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, IT_PCMPEQB, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_RM, SC_None, 0x0F, 0x74, -1);
-}
-
-static
-void decode0F_7E(DContext* c)
-{
-    switch(c->ps) {
-    case PS_66:
-        // movd/q r/m 32/64,xmm (MR)
-        c->oe = OE_MR;
-        c->vt = (c->rex & REX_MASK_W) ? VT_64 : VT_32;
-        c->it = (c->rex & REX_MASK_W) ? IT_MOVQ : IT_MOVD;
-        parseModRM(c, c->vt, RT_GV, &c->o1, &c->o2, 0);
-        break;
-    case PS_F3:
-        // movq xmm1, xmm2/m64 (RM) - move from xmm2/m64 to xmm1
-        c->oe = OE_RM;
-        c->vt = VT_64;
-        c->it = IT_MOVQ;
-        parseModRM(c, c->vt, RT_VV, &c->o2, &c->o1, 0);
-        break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    if (c->rex & REX_MASK_W) c->ps |= PS_REXW; // pass-through REX_W setting
-    attachPassthrough(c->ii, c->ps, c->oe, SC_dstDyn, 0x0F, 0x7E, -1);
-}
-
-static
-void decode0F_7F(DContext* c)
-{
-    switch(c->ps) {
-    case PS_F3:
-        // movdqu xmm2/m128,xmm1 (MR)
-        // - move unaligned double quadword from xmm1 to xmm2/m128.
-        c->vt = VT_128; c->it = IT_MOVDQU; break;
-    case PS_66:
-        // movdqa xmm2/m128,xmm1 (MR)
-        // - move aligned double quadword from xmm1 to xmm2/m128.
-        c->vt = VT_128; c->it = IT_MOVDQA; break;
-    default: addSimple(c->r, c, IT_Invalid); return;
-    }
-    parseModRM(c, c->vt, RT_VV, &c->o1, &c->o2, 0);
-    c->ii = addBinaryOp(c->r, c, c->it, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_MR, SC_None, 0x0F, 0x7F, -1);
-}
-
-// 0x80: jo rel32
-// 0x81: jno rel32
-// 0x82: jc/jb/jnae rel32
-// 0x83: jnc/jnb/jae rel32
-// 0x84: jz/je rel32
-// 0x85: jnz/jne rel32
-// 0x86: jbe/jna rel32
-// 0x87: ja/jnbe rel32
-// 0x88: js rel32
-// 0x89: jns rel32
-// 0x8A: jp/jpe rel32
-// 0x8B: jnp/jpo rel32
-// 0x8C: jl/jnge rel32
-// 0x8D: jge/jnl rel32
-// 0x8E: jle/jng rel32
-// 0x8F: jg/jnle rel32
-static
-void decode0F_80(DContext* c)
-{
-    c->o1.type = OT_Imm64;
-    c->o1.val = (uint64_t) (c->f + c->off + 4 + *(int32_t*)(c->f + c->off));
-    c->off += 4;
-    switch (c->opc2) {
-    case 0x80: c->it = IT_JO; break;
-    case 0x81: c->it = IT_JNO; break;
-    case 0x82: c->it = IT_JC; break;
-    case 0x83: c->it = IT_JNC; break;
-    case 0x84: c->it = IT_JZ; break;
-    case 0x85: c->it = IT_JNZ; break;
-    case 0x86: c->it = IT_JBE; break;
-    case 0x87: c->it = IT_JA; break;
-    case 0x88: c->it = IT_JS; break;
-    case 0x89: c->it = IT_JNS; break;
-    case 0x8A: c->it = IT_JP; break;
-    case 0x8B: c->it = IT_JNP; break;
-    case 0x8C: c->it = IT_JL; break;
-    case 0x8D: c->it = IT_JGE; break;
-    case 0x8E: c->it = IT_JLE; break;
-    case 0x8F: c->it = IT_JG; break;
-    default: assert(0);
-    }
-    c->it = IT_JO + (c->opc2 & 0xf);
-    c->ii = addUnaryOp(c->r, c, c->it, &c->o1);
-    c->ii->vtype = VT_Implicit; // jump address size is implicit
-    c->exit = true;
-}
-
-static
-void decode0F_B6(DContext* c)
-{
-    // movzbl r16/32/64,r/m8 (RM): move byte to (d)word, zero-extend
-    parseModRM(c, c->vt, RT_GG, &c->o2, &c->o1, 0);
-    opOverwriteType(&c->o2, VT_8); // source always 8bit
-    addBinaryOp(c->r, c, IT_MOVZX, c->vt, &c->o1, &c->o2);
-}
-
-static
-void decode0F_B7(DContext* c)
-{
-    // movzbl r32/64,r/m16 (RM): move word to (d/q)word, zero-extend
-    assert((c->vt == VT_32) || (c->vt == VT_64));
-    parseModRM(c, c->vt, RT_GG, &c->o2, &c->o1, 0);
-    opOverwriteType(&c->o2, VT_16); // source always 16bit
-    addBinaryOp(c->r, c, IT_MOVZX, c->vt, &c->o1, &c->o2);
-}
-
-static
-void decode0F_BE(DContext* c)
-{
-    // movsx r16/32/64,r/m8 (RM): byte to (q/d)word with sign-extension
-    parseModRM(c, c->vt, RT_GG, &c->o2, &c->o1, 0);
-    opOverwriteType(&c->o2, VT_8); // source always 8bit
-    addBinaryOp(c->r, c, IT_MOVSX, c->vt, &c->o1, &c->o2);
-}
-
-static
-void decode0F_BF(DContext* c)
-{
-    // movsx r32/64,r/m16 (RM). word to (q/d)word with sign-extension
-    assert((c->vt == VT_32) || (c->vt == VT_64));
-    parseModRM(c, c->vt, RT_GG, &c->o2, &c->o1, 0);
-    opOverwriteType(&c->o2, VT_16); // source always 16bit
-    addBinaryOp(c->r, c, IT_MOVSX, c->vt, &c->o1, &c->o2);
-}
-
-static
-void decode0F_D4(DContext* c)
-{
-    // paddq mm1,mm2/m64 (RM)
-    // - add quadword integer mm2/m64 to mm1
-    // paddq xmm1,xmm2/m64 (RM)
-    // - add packed quadword xmm2/m128 to xmm1
-    c->vt = (c->ps & PS_66) ? VT_128 : VT_64;
-    parseModRM(c, c->vt, RT_VV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, IT_PADDQ, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_RM, SC_None, 0x0F, 0xD4, -1);
-}
-
-static
-void decode0F_D6(DContext* c)
-{
-    // movq xmm2/m64,xmm1 (MR)
-    assert(c->ps == PS_66);
-    parseModRM(c, VT_64, RT_VV, &c->o1, &c->o2, 0);
-    c->ii = addBinaryOp(c->r, c, IT_MOVQ, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, c->ps, OE_MR, SC_None, 0x0F, 0xD6, -1);
-}
-
-static
-void decode0F_D7(DContext* c)
-{
-    // pmovmskb r,mm 64/128 (RM): minimum of packed bytes
-    c->vt = (c->ps & PS_66) ? VT_128 : VT_64;
-    parseModRM(c, c->vt, RT_VG, &c->o2, &c->o1, 0);
-    opOverwriteType(&c->o1, VT_32); // result always 32bit
-    c->ii = addBinaryOp(c->r, c, IT_PMOVMSKB, VT_32, &c->o1, &c->o2);
-    attachPassthrough(c->ii, (PrefixSet)(c->ps & PS_66), OE_RM, SC_dstDyn,
-                      0x0F, 0xD7, -1);
-}
-
-static
-void decode0F_DA(DContext* c)
-{
-    // pminub mm,mm/m 64/128 (RM): minimum of packed bytes
-    c->vt = (c->ps & PS_66) ? VT_128 : VT_64;
-    parseModRM(c, c->vt, RT_VV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, IT_PMINUB, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, (PrefixSet)(c->ps & PS_66), OE_RM, SC_None,
-                      0x0F, 0xDA, -1);
-}
-
-static
-void decode0F_EF(DContext* c)
-{
-    // pxor xmm1,xmm2/m 64/128 (RM)
-    c->vt = (c->ps & PS_66) ? VT_128 : VT_64;
-    parseModRM(c, c->vt, RT_VV, &c->o2, &c->o1, 0);
-    c->ii = addBinaryOp(c->r, c, IT_PXOR, VT_Implicit, &c->o1, &c->o2);
-    attachPassthrough(c->ii, (PrefixSet)(c->ps & PS_66), OE_RM, SC_None,
-                      0x0F, 0xEF, -1);
-}
-
-
-//
-// handlers for single-byte opcodes
-//
-
-static
-void decode_50(DContext* c)
-{
-    // 0x50-57: push r16/r64
-    Reg reg = Reg_AX + (c->opc1 - 0x50);
-    c->vt = VT_64;
-    if (c->rex & REX_MASK_B) reg += 8;
-    if (c->ps & PS_66) c->vt = VT_16;
-    addUnaryOp(c->r, c, IT_PUSH, getRegOp(c->vt, reg));
-}
-
-static
-void decode_58(DContext* c)
-{
-    // 0x58-5F: pop r16/r64
-    Reg reg = Reg_AX + (c->opc1 - 0x58);
-    c->vt = VT_64;
-    if (c->rex & REX_MASK_B) reg += 8;
-    if (c->ps & PS_66) c->vt = VT_16;
-    addUnaryOp(c->r, c, IT_POP, getRegOp(c->vt, reg));
-}
-
-static
-void decode_63(DContext* c)
-{
-    // movsx r64,r/m32 (RM) mov with sign extension
-    assert(c->rex & REX_MASK_W);
-    parseModRM(c, VT_None, RT_GG, &c->o2, &c->o1, 0);
-    // src is 32 bit
-    switch(c->o2.type) {
-    case OT_Reg64: c->o2.type = OT_Reg32; break;
-    case OT_Ind64: c->o2.type = OT_Ind32; break;
-    default: assert(0);
-    }
-    addBinaryOp(c->r, c, IT_MOVSX, VT_None, &c->o1, &c->o2);
-}
-
-static
-void decode_70(DContext* c)
-{
-    // 0x70: jo rel8
-    // 0x71: jno rel8
-    // 0x72: jc/jb/jnae rel8
-    // 0x73: jnc/jnb/jae rel8
-    // 0x74: jz/je rel8
-    // 0x75: jnz/jne rel8
-    // 0x76: jbe/jna rel8
-    // 0x77: ja/jnbe rel8
-    // 0x78: js rel8
-    // 0x79: jns rel8
-    // 0x7A: jp/jpe rel8
-    // 0x7B: jnp/jpo rel8
-    // 0x7C: jl/jnge rel8
-    // 0x7D: jge/jnl rel8
-    // 0x7E: jle/jng rel8
-    // 0x7F: jg/jnle rel8
-    c->o1.type = OT_Imm64;
-    c->o1.val = (uint64_t) (c->f + c->off + 1 + *(int8_t*)(c->f + c->off));
-    c->off += 1;
-    switch (c->opc1) {
-    case 0x70: c->it = IT_JO; break;
-    case 0x71: c->it = IT_JNO; break;
-    case 0x72: c->it = IT_JC; break;
-    case 0x73: c->it = IT_JNC; break;
-    case 0x74: c->it = IT_JZ; break;
-    case 0x75: c->it = IT_JNZ; break;
-    case 0x76: c->it = IT_JBE; break;
-    case 0x77: c->it = IT_JA; break;
-    case 0x78: c->it = IT_JS; break;
-    case 0x79: c->it = IT_JNS; break;
-    case 0x7A: c->it = IT_JP; break;
-    case 0x7B: c->it = IT_JNP; break;
-    case 0x7C: c->it = IT_JL; break;
-    case 0x7D: c->it = IT_JGE; break;
-    case 0x7E: c->it = IT_JLE; break;
-    case 0x7F: c->it = IT_JG; break;
-    default: assert(0);
-    }
-    c->ii = addUnaryOp(c->r, c, c->it, &c->o1);
-    c->ii->vtype = VT_Implicit; // jump address size is implicit
-    c->exit = true;
-}
-
-static
-void decode_8D(DContext* c)
-{
-    // lea r16/32/64,m (RM)
-    parseModRM(c, c->vt, RT_GG, &c->o2, &c->o1, 0);
-    assert(opIsInd(&c->o2)); // TODO: bad code error
-    addBinaryOp(c->r, c, IT_LEA, c->vt, &c->o1, &c->o2);
-}
-
-static
-void decode_8F_0(DContext* c)
-{
-    // pop r/m 16/64
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, 0);
-    // default operand type is 64, not 32
-    if (c->vt == VT_32)
-        opOverwriteType(&c->o1, VT_64);
-    else
-        assert(c->vt == VT_16);
-    addUnaryOp(c->r, c, IT_POP, &c->o1);
-}
-
-static
-void decode_98(DContext* c)
-{
-    // cltq (Intel: cdqe - sign-extend eax to rax)
-    c->vt = (c->rex & REX_MASK_W) ? VT_64 : VT_32;
-    addSimpleVType(c->r, c, IT_CLTQ, c->vt);
-}
-
-static
-void decode_99(DContext* c)
-{
-    // cqto (Intel: cqo - sign-extend rax to rdx/rax, eax to edx/eax)
-    c->vt = (c->rex & REX_MASK_W) ? VT_128 : VT_64;
-    addSimpleVType(c->r, c, IT_CQTO, c->vt);
-}
-
-
-static
-void decode_B0(DContext* c)
-{
-    // B0-B7: mov r8,imm8
-    // B8-BF: mov r32/64,imm32/64
-    if ((c->opc1 >= 0xB0) && (c->opc1 <= 0xB7)) c->vt = VT_8;
-    c->o1.reg = Reg_AX + (c->opc1 & 7);
-    if (c->rex & REX_MASK_B) c->o1.reg += 8;
-    c->o1.type = getGPRegOpType(c->vt);
-    parseImm(c, c->vt, &c->o2, true);
-    addBinaryOp(c->r, c, IT_MOV, c->vt, &c->o1, &c->o2);
-}
-
-static
-void decode_C0(DContext* c)
-{
-    // 1st op 8bit
-    c->vt = VT_8;
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &c->digit);
-    // 2nd op imm8
-    parseImm(c, VT_8, &c->o2, false);
-    switch(c->digit) {
-    case 4: // shl r/m8,imm8 (MI) (= sal)
-        addBinaryOp(c->r, c, IT_SHL, c->vt, &c->o1, &c->o2); break;
-    case 5: // shr r/m8,imm8 (MI)
-        addBinaryOp(c->r, c, IT_SHR, c->vt, &c->o1, &c->o2); break;
-    case 7: // sar r/m8,imm8 (MI)
-        addBinaryOp(c->r, c, IT_SAR, c->vt, &c->o1, &c->o2); break;
-    default:
-        addSimple(c->r, c, IT_Invalid);
-        break;
-    }
-}
-
-static
-void decode_C1(DContext* c)
-{
-    // 1st op 16/32/64
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &c->digit);
-    // 2nd op imm8
-    parseImm(c, VT_8, &c->o2, false);
-    switch(c->digit) {
-    case 4: // shl r/m 16/32/64,imm8 (MI) (= sal)
-        addBinaryOp(c->r, c, IT_SHL, c->vt, &c->o1, &c->o2); break;
-    case 5: // shr r/m 16/32/64,imm8 (MI)
-        addBinaryOp(c->r, c, IT_SHR, c->vt, &c->o1, &c->o2); break;
-    case 7: // sar r/m 16/32/64,imm8 (MI)
-        addBinaryOp(c->r, c, IT_SAR, c->vt, &c->o1, &c->o2); break;
-    default:
-        addSimple(c->r, c, IT_Invalid);
-        break;
-    }
-}
-
-static
-void decode_C6(DContext* c)
-{
-    c->vt = VT_8; // all sub-opcodes use 8bit operand type
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &c->digit);
-    switch(c->digit) {
-    case 0: // mov r/m8, imm8
-        parseImm(c, c->vt, &c->o2, false);
-        addBinaryOp(c->r, c, IT_MOV, c->vt, &c->o1, &c->o2);
-        break;
-    default: addSimple(c->r, c, IT_Invalid); break;
-    }
-}
-
-static
-void decode_C7(DContext* c)
-{
-    // for 16/32/64
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &c->digit);
-    switch(c->digit) {
-    case 0: // mov r/m 16/32/64, imm16/32/32se (sign extended)
-        parseImm(c, c->vt, &c->o2, false);
-        addBinaryOp(c->r, c, IT_MOV, c->vt, &c->o1, &c->o2);
-        break;
-    default: addSimple(c->r, c, IT_Invalid); break;
-    }
-}
-
-static
-void decode_D0(DContext* c)
-{
-    c->vt = VT_8;
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &c->digit);
-    switch(c->digit) {
-    case 4: // shl r/m8,1 (M1) (= sal)
-        addUnaryOp(c->r, c, IT_SHL, &c->o1); break;
-    case 5: // shr r/m8,1 (M1)
-        addUnaryOp(c->r, c, IT_SHR, &c->o1); break;
-    case 7: // sar r/m8,1 (M1)
-        addUnaryOp(c->r, c, IT_SAR, &c->o1); break;
-    default:
-        addSimple(c->r, c, IT_Invalid); break;
-    }
-}
-
-static
-void decode_D1(DContext* c)
-{
-    // for 16/32/64
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &c->digit);
-    switch(c->digit) {
-    case 4: // shl r/m16/32/64,1 (M1) (= sal)
-        addUnaryOp(c->r, c, IT_SHL, &c->o1); break;
-    case 5: // shr r/m16/32/64,1 (M1)
-        addUnaryOp(c->r, c, IT_SHR, &c->o1); break;
-    case 7: // sar r/m16/32/64,1 (M1)
-        addUnaryOp(c->r, c, IT_SAR, &c->o1); break;
-    default:
-        addSimple(c->r, c, IT_Invalid); break;
-    }
-}
-
-static
-void decode_D2(DContext* c)
-{
-    c->vt = VT_8;
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &c->digit);
-    setRegOp(&c->o2, VT_8, Reg_CX);
-    switch(c->digit) {
-    case 4: // shl r/m8,cl (MC16/32/64) (= sal)
-        addBinaryOp(c->r, c, IT_SHL, c->vt, &c->o1, &c->o2); break;
-    case 5: // shr r/m8,cl (MC)
-        addBinaryOp(c->r, c, IT_SHR, c->vt, &c->o1, &c->o2); break;
-    case 7: // sar r/m8,cl (MC)
-        addBinaryOp(c->r, c, IT_SAR, c->vt, &c->o1, &c->o2); break;
-    default:
-        addSimple(c->r, c, IT_Invalid); break;
-    }
-}
-
-static
-void decode_D3(DContext* c)
-{
-    // for 16/32/64
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &c->digit);
-    setRegOp(&c->o2, VT_8, Reg_CX);
-    switch(c->digit) {
-    case 4: // shl r/m16/32/64,cl (MC) (= sal)
-        addBinaryOp(c->r, c, IT_SHL, c->vt, &c->o1, &c->o2); break;
-    case 5: // shr r/m16/32/64,cl (MC)
-        addBinaryOp(c->r, c, IT_SHR, c->vt, &c->o1, &c->o2); break;
-    case 7: // sar r/m16/32/64,cl (MC)
-        addBinaryOp(c->r, c, IT_SAR, c->vt, &c->o1, &c->o2); break;
-    default:
-        addSimple(c->r, c, IT_Invalid); break;
-    }
-}
-
-static
-void decode_E8(DContext* c)
-{
-    // call rel32
-    c->o1.type = OT_Imm64;
-    c->o1.val = (uint64_t) (c->f + c->off + 4 + *(int32_t*)(c->f + c->off));
-    c->off += 4;
-    addUnaryOp(c->r, c, IT_CALL, &c->o1);
-    c->exit = true;
-}
-
-static
-void decode_E9(DContext* c)
-{
-    // jmp rel32: relative, displacement relative to next instruction
-    c->o1.type = OT_Imm64;
-    c->o1.val = (uint64_t) (c->f + c->off + 4 + *(int32_t*)(c->f + c->off));
-    c->off += 4;
-    addUnaryOp(c->r, c, IT_JMP, &c->o1);
-    c->exit = true;
-}
-
-static
-void decode_EB(DContext* c)
-{
-    // jmp rel8: relative, displacement relative to next instruction
-    c->o1.type = OT_Imm64;
-    c->o1.val = (uint64_t) (c->f + c->off + 1 + *(int8_t*)(c->f + c->off));
-    c->off += 1;
-    addUnaryOp(c->r, c, IT_JMP, &c->o1);
-    c->exit = true;
-}
-
-static
-void decode_F6(DContext* c)
-{
-    // source always 8bit
-    c->vt = VT_8;
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &c->digit);
-    switch(c->digit) {
-    case 0: // test r/m8,imm8 (MI)
-        parseImm(c, c->vt, &c->o2, false);
-        addBinaryOp(c->r, c, IT_TEST, c->vt, &c->o1, &c->o2);
-        break;
-    case 2: // not r/m8
-        addUnaryOp(c->r, c, IT_NOT, &c->o1); break;
-    case 3: // neg r/m8
-        addUnaryOp(c->r, c, IT_NEG, &c->o1); break;
-    case 4: // mul r/m8 (unsigned mul ax by r/m8)
-        addUnaryOp(c->r, c, IT_MUL, &c->o1); break;
-    case 5: // imul r/m8 (signed mul ax/eax/rax by r/m8)
-        addUnaryOp(c->r, c, IT_IMUL, &c->o1); break;
-    case 6: // div r/m8 (unsigned div ax by r/m8, rem/quot in ah:al)
-        addUnaryOp(c->r, c, IT_DIV, &c->o1); break;
-    case 7: // idiv r/m8 (signed div ax by r/m8, rem/quot in ah:al)
-        addUnaryOp(c->r, c, IT_IDIV1, &c->o1); break;
-    default: addSimple(c->r, c, IT_Invalid); break;
-    }
-}
-
-static
-void decode_F7(DContext* c)
-{
-    parseModRM(c, c->vt, RT_GG, &c->o1, 0, &c->digit);
-    switch(c->digit) {
-    case 0: // test r/m16/32/64,imm16/32/32se (MI)
-        parseImm(c, c->vt, &c->o2, false);
-        addBinaryOp(c->r, c, IT_TEST, c->vt, &c->o1, &c->o2);
-        break;
-    case 2: // not r/m 16/32/64
-        addUnaryOp(c->r, c, IT_NOT, &c->o1); break;
-    case 3: // neg r/m 16/32/64
-        addUnaryOp(c->r, c, IT_NEG, &c->o1); break;
-    case 4: // mul r/m 16/32/64 (unsigned mul ax/eax/rax by r/m)
-        addUnaryOp(c->r, c, IT_MUL, &c->o1); break;
-    case 5: // imul r/m 16/32/64 (signed mul ax/eax/rax by r/m)
-        addUnaryOp(c->r, c, IT_IMUL, &c->o1); break;
-    case 6: // div r/m 16/32/64 (unsigned div dx:ax/edx:eax/rdx:rax by r/m)
-        addUnaryOp(c->r, c, IT_DIV, &c->o1); break;
-    case 7: // idiv r/m 16/32/64 (signed div dx:ax/edx:eax/rdx:rax by r/m)
-        addUnaryOp(c->r, c, IT_IDIV1, &c->o1); break;
-    default: addSimple(c->r, c, IT_Invalid); break;
-    }
-}
-
-
-static
-void decode_FE(DContext* c)
-{
-    parseModRM(c, VT_8, RT_G, &c->o1, 0, &c->digit);
-    switch(c->digit) {
-    case 0: // inc r/m8
-        addUnaryOp(c->r, c, IT_INC, &c->o1); break;
-    case 1: // dec r/m8
-        addUnaryOp(c->r, c, IT_DEC, &c->o1); break;
-    default: addSimple(c->r, c, IT_Invalid); break;
-    }
-}
-
-static
-void decode_FF(DContext* c)
-{
-    parseModRM(c, c->vt, RT_G, &c->o1, 0, &c->digit);
-    switch(c->digit) {
-    case 0: // inc r/m 16/32/64
-        addUnaryOp(c->r, c, IT_INC, &c->o1); break;
-    case 1: // dec r/m 16/32/64
-        addUnaryOp(c->r, c, IT_DEC, &c->o1); break;
-
-    case 2:
-        // call r/m64
-        assert(c->vt == VT_64); // only 64bit target allowed in 64bit mode
-        addUnaryOp(c->r, c, IT_CALL, &c->o1);
-        c->exit = true;
-        break;
-
-    case 4:
-        // jmp* r/m64: absolute indirect
-        assert(c->rex == 0);
-        opOverwriteType(&c->o1, VT_64);
-        addUnaryOp(c->r, c, IT_JMPI, &c->o1);
-        c->exit = true;
-        break;
-
-    case 6: // push r/m 16/64
-        // default operand type is 64, not 32
-        if (c->vt == VT_32)
-            opOverwriteType(&c->o1, VT_64);
+    do {
+        int prefix = fp[off];
+        if (prefix == 0x2E)
+            ps |= PS_2E;
+        else if (prefix >= 0x40 && prefix <= 0x4F)
+            rex = prefix & 0xF;
+        else if (prefix == 0x64)
+            segmentOverride = OSO_UseFS;
+        else if (prefix == 0x65)
+            segmentOverride = OSO_UseGS;
+        else if (prefix == 0x66)
+            ps |= PS_66;
+        else if (prefix == 0xF2)
+            ps |= PS_F2;
+        else if (prefix == 0xF3)
+            ps |= PS_F3;
         else
-            assert(c->vt == VT_16);
-        addUnaryOp(c->r, c, IT_PUSH, &c->o1);
-        break;
+            break;
+        off++;
+    } while (true);
 
-    default:
-        addSimple(c->r, c, IT_Invalid);
-        break;
+    int opc1 = fp[off++];
+    int opc2 = -1;
+    int opc3 = -1;
+    if (opc1 == 0x0F)
+    {
+        opc2 = fp[off++];
+        if (opc2 == 0x38 || opc2 == 0x3A)
+            opc3 = fp[off++];
     }
+    int opc[3] = {opc1, opc2, opc3};
+
+    bool success = false;
+
+    // Note: instrDescriptors is defined in instr-descriptors.c
+    for (int i = 0; instrDescriptors[i].encoding != OE_Invalid && !success; i++)
+    {
+        const InstrDescriptor* desc = &instrDescriptors[i];
+        int reg = opc[desc->opcCount - 1] & 0x7;
+        int condition = opc[desc->opcCount - 1] & 0xF;
+
+        if (desc->prefixes != ps)
+            continue;
+
+        if (desc->digit != -1 && desc->digit != (fp[off] & 56) >> 3)
+            continue;
+
+        if (desc->opcCount >= 2 && desc->opc[0] != opc[0])
+            continue;
+
+        if (desc->opcCount >= 3 && desc->opc[1] != opc[1])
+            continue;
+
+        // This leaves to check whether the last opcode is matching. We now
+        // modify the opcode in the array as it is not used after this.
+
+        // Temporary (!) variables
+        int lastOpc = opc[desc->opcCount - 1];
+        int expectedLastOpc = desc->opc[desc->opcCount - 1];
+
+        // Cases where operand is encoded in the opcode
+        if ((desc->encoding == OE_O || desc->encoding == OE_OI) && expectedLastOpc == (lastOpc & ~0x7))
+            lastOpc = expectedLastOpc;
+
+        // Case where we have a condition encoded in the opcode
+        if (desc->conditional && expectedLastOpc == (lastOpc & ~0xF))
+            lastOpc = expectedLastOpc;
+
+        if (lastOpc != expectedLastOpc)
+            continue;
+
+        success = true;
+
+        bool o1IsVec = (desc->regType & 2) != 0;
+        bool o2IsVec = (desc->regType & 1) != 0;
+        ValType vti = rex & REX_MASK_W ? VT_64 : VT_32;
+
+        if (instrIsJcc(desc->type) || desc->type == IT_JMP || desc->type == IT_JMPI ||
+            desc->type == IT_RET || desc->type == IT_CALL)
+            *isTerminator = true;
+
+        // Allocate next instruction.
+        instr = r->decInstr + r->decInstrCount;
+        assert(r->decInstrCount < r->decInstrCapacity);
+        r->decInstrCount++;
+
+        switch (desc->encoding)
+        {
+            case OE_M:
+                off += parseModRM(fp + off, rex, segmentOverride, 0, 0, &o1, 0, &digit);
+                if (desc->vto1 != VT_None && desc->vto1 != VT_Implicit)
+                    opOverwriteType(&o1, desc->vto1);
+                if (desc->vti != VT_None)
+                    vti = desc->vti;
+                initUnaryInstr(instr, desc->type + (desc->conditional ? condition : 0), &o1);
+                break;
+            case OE_M1:
+                off += parseModRM(fp + off, rex, segmentOverride, 0, 0, &o1, 0, &digit);
+                if (desc->vto1 != VT_None && desc->vto1 != VT_Implicit)
+                    opOverwriteType(&o1, desc->vto1);
+                if (desc->vti != VT_None)
+                    vti = desc->vti;
+                o2.type = OT_Imm8;
+                o2.val = 1;
+                initBinaryInstr(instr, desc->type, vti, &o1, &o2);
+                break;
+            case OE_MI:
+                off += parseModRM(fp + off, rex, segmentOverride, 0, 0, &o1, 0, &digit);
+                if (desc->vto1 != VT_None && desc->vto1 != VT_Implicit)
+                    opOverwriteType(&o1, desc->vto1);
+                if (desc->vti != VT_None)
+                    vti = desc->vti;
+                switch (desc->immsize)
+                {
+                    case 8: o2.type = OT_Imm8; o2.val = *(uint8_t*)(fp + off); off += 1; break;
+                    case 16: o2.type = OT_Imm16; o2.val = *(uint16_t*)(fp + off); off += 2; break;
+                    case 32: o2.type = OT_Imm32; o2.val = *(uint32_t*)(fp + off); off += 4; break;
+                    case 64: o2.type = OT_Imm64; o2.val = *(uint64_t*)(fp + off); off += 8; break;
+                    default: assert(0);
+                }
+                initBinaryInstr(instr, desc->type, vti, &o1, &o2);
+                break;
+            case OE_MC:
+                off += parseModRM(fp + off, rex, segmentOverride, 0, 0, &o1, 0, &digit);
+                if (desc->vto1 != VT_None && desc->vto1 != VT_Implicit)
+                    opOverwriteType(&o1, desc->vto1);
+                if (desc->vti != VT_None)
+                    vti = desc->vti;
+                o2.type = OT_Reg8;
+                o2.reg = Reg_CX;
+                initBinaryInstr(instr, desc->type, vti, &o1, &o2);
+                break;
+            case OE_RM:
+            case OE_MR:
+                if (desc->encoding == OE_MR)
+                    off += parseModRM(fp + off, rex, segmentOverride, o1IsVec, o2IsVec, &o1, &o2, &digit);
+                else
+                    off += parseModRM(fp + off, rex, segmentOverride, o2IsVec, o1IsVec, &o2, &o1, &digit);
+                if (desc->vto1 != VT_None && desc->vto1 != VT_Implicit)
+                    opOverwriteType(&o1, desc->vto1);
+                if (desc->vto2 != VT_None && desc->vto2 != VT_Implicit)
+                    opOverwriteType(&o2, desc->vto2);
+                if (desc->vto1 == VT_Implicit && !o1IsVec)
+                    opOverwriteType(&o1, vti);
+                if (desc->vto2 == VT_Implicit && !o2IsVec)
+                    opOverwriteType(&o2, vti);
+                if (desc->vti != VT_None)
+                    vti = desc->vti;
+                initBinaryInstr(instr, desc->type + (desc->conditional ? condition : 0), vti, &o1, &o2);
+                break;
+            case OE_RMI:
+                off += parseModRM(fp + off, rex, segmentOverride, o2IsVec, o1IsVec, &o2, &o1, &digit);
+                if (desc->vto1 != VT_None && desc->vto1 != VT_Implicit)
+                    opOverwriteType(&o1, desc->vto1);
+                if (desc->vto2 != VT_None && desc->vto2 != VT_Implicit)
+                    opOverwriteType(&o2, desc->vto2);
+                if (desc->vto1 == VT_Implicit && !o1IsVec)
+                    opOverwriteType(&o1, vti);
+                if (desc->vto2 == VT_Implicit && !o2IsVec)
+                    opOverwriteType(&o2, vti);
+                if (desc->vti != VT_None)
+                    vti = desc->vti;
+                switch (desc->immsize)
+                {
+                    case 8: o3.type = OT_Imm8; o3.val = *(uint8_t*)(fp + off); off += 1; break;
+                    case 16: o3.type = OT_Imm16; o3.val = *(uint16_t*)(fp + off); off += 2; break;
+                    case 32: o3.type = OT_Imm32; o3.val = *(uint32_t*)(fp + off); off += 4; break;
+                    case 64: o3.type = OT_Imm64; o3.val = *(uint64_t*)(fp + off); off += 8; break;
+                    default: assert(0);
+                }
+                initTernaryInstr(instr, desc->type, &o1, &o2, &o3);
+                break;
+            case OE_O:
+                o1.reg = (o1IsVec ? Reg_X0 : Reg_AX) + reg;
+                o1.type = OT_Reg8;
+                if (rex & REX_MASK_B)
+                    o1.reg += 8;
+                if (desc->vti != VT_None)
+                    vti = desc->vti;
+                opOverwriteType(&o1, vti);
+                initUnaryInstr(instr, desc->type, &o1);
+                break;
+            case OE_OI:
+                o1.reg = (o1IsVec ? Reg_X0 : Reg_AX) + reg;
+                o1.type = OT_Reg8;
+                immsize = desc->immsize;
+                if (desc->immsize == 0)
+                    immsize = rex & REX_MASK_W ? 64 : 32;
+                if (rex & REX_MASK_B)
+                    o1.reg += 8;
+                if (desc->vti != VT_None)
+                    vti = desc->vti;
+                opOverwriteType(&o1, vti);
+                switch (immsize)
+                {
+                    case 8: o2.type = OT_Imm8; o2.val = *(uint8_t*)(fp + off); off += 1; break;
+                    case 16: o2.type = OT_Imm16; o2.val = *(uint16_t*)(fp + off); off += 2; break;
+                    case 32: o2.type = OT_Imm32; o2.val = *(uint32_t*)(fp + off); off += 4; break;
+                    case 64: o2.type = OT_Imm64; o2.val = *(uint64_t*)(fp + off); off += 8; break;
+                    default: assert(0);
+                }
+                initBinaryInstr(instr, desc->type, vti, &o1, &o2);
+                break;
+            case OE_I:
+                switch (desc->immsize)
+                {
+                    case 8: o1.type = OT_Imm8; o1.val = *(uint8_t*)(fp + off); off += 1; break;
+                    case 16: o1.type = OT_Imm16; o1.val = *(uint16_t*)(fp + off); off += 2; break;
+                    case 32: o1.type = OT_Imm32; o1.val = *(uint32_t*)(fp + off); off += 4; break;
+                    case 64: o1.type = OT_Imm64; o1.val = *(uint64_t*)(fp + off); off += 8; break;
+                    default: assert(0);
+                }
+                if (desc->vti != VT_None)
+                    vti = desc->vti;
+                initUnaryInstr(instr, desc->type, &o1);
+                instr->vtype = vti;
+                break;
+            case OE_IA:
+                switch (desc->immsize)
+                {
+                    case 8: o2.type = OT_Imm8; o2.val = *(uint8_t*)(fp + off); off += 1; break;
+                    case 16: o2.type = OT_Imm16; o2.val = *(uint16_t*)(fp + off); off += 2; break;
+                    case 32: o2.type = OT_Imm32; o2.val = *(uint32_t*)(fp + off); off += 4; break;
+                    case 64: o2.type = OT_Imm64; o2.val = *(uint64_t*)(fp + off); off += 8; break;
+                    default: assert(0);
+                }
+                if (desc->vti != VT_None)
+                    vti = desc->vti;
+                initBinaryInstr(instr, desc->type, vti, getRegOp(vti, Reg_AX), &o2);
+                break;
+            case OE_D:
+                o1.type = OT_Imm64;
+                switch (desc->immsize)
+                {
+                    case 8: o1.val = *(int8_t*)(fp + off); off += 1; break;
+                    case 16: o1.val = *(int16_t*)(fp + off); off += 2; break;
+                    case 32: o1.val = *(int32_t*)(fp + off); off += 4; break;
+                    case 64: o1.val = *(int64_t*)(fp + off); off += 8; break;
+                    default: assert(0);
+                }
+                o1.val += (uintptr_t) fp + off;
+                initUnaryInstr(instr, desc->type + (desc->conditional ? condition : 0), &o1);
+                if (instrIsJcc(desc->type))
+                    instr->vtype = VT_Implicit;
+                break;
+            case OE_NP:
+                if (desc->vti != VT_Implicit)
+                    vti = desc->vti;
+                if (desc->opc[0] == 0x99) // CQTO, CQO
+                    vti = rex & REX_MASK_W ? VT_128 : VT_64;
+                initSimpleInstr(instr, desc->type);
+                if (desc->vti != VT_None)
+                    instr->vtype = vti;
+                break;
+            case OE_None:
+                off += desc->decodeHandler(fp + off, instr, desc, rex, segmentOverride);
+                break;
+            default:
+                assert(0);
+        }
+
+        instr->addr = (uintptr_t) fp;
+        instr->len = off;
+
+        attachPassthrough(instr, ps, desc->encoding, opc1, opc2, opc3);
+    }
+
+    if (!success)
+    {
+        printf("Error while decoding. Bytes: %s\n", dbrew_stringify_bytes(fp, 15));
+        return -1;
+    }
+
+    return off;
 }
 
-static
-void initDecodeTables(void)
+DBB*
+dbrew_decode(Rewriter* r, uint64_t f)
 {
-    static bool done = false;
-    // initialize only once
-    if (done) return;
-    done = true;
+    if (f == 0)
+        return NULL;
 
-    for(int i = 0; i<256; i++) {
-        opcTable[i].t   = OT_Invalid;
-        opcTable0F[i].t = OT_Invalid;
-    }
+    if (r->decBB == 0)
+        initRewriter(r);
 
-    // 0x00: add r/m8,r8 (MR, dst: r/m, src: r)
-    // 0x01: add r/m,r 16/32/64 (MR, dst: r/m, src: r)
-    // 0x02: add r8,r/m8 (RM, dst: r, src: r/m)
-    // 0x03: add r,r/m 16/32/64 (RM, dst: r, src: r/m)
-    // 0x04: add al,imm8 (I)
-    // 0x05: add ax/eax/rax,imm16/32/32se (I) - (se: sign extended)
-    setOpc(0x00, IT_ADD, VT_8,   parseMR, addBInstr, 0);
-    setOpc(0x01, IT_ADD, VT_Def, parseMR, addBInstr, 0);
-    setOpc(0x02, IT_ADD, VT_8,   parseRM, addBInstr, 0);
-    setOpc(0x03, IT_ADD, VT_Def, parseRM, addBInstr, 0);
-    setOpc(0x04, IT_ADD, VT_8,   setO1RegA, parseI2, addBInstr);
-    setOpc(0x05, IT_ADD, VT_Def, setO1RegA, parseI2, addBInstr);
+    for(int i = 0; i < r->decBBCount; i++)
+        if (r->decBB[i].addr == f)
+            return &r->decBB[i];
 
-    // 0x08: or r/m8,r8 (MR, dst: r/m, src: r)
-    // 0x09: or r/m,r 16/32/64 (MR, dst: r/m, src: r)
-    // 0x0A: or r8,r/m8 (RM, dst: r, src: r/m)
-    // 0x0B: or r,r/m 16/32/64 (RM, dst: r, src: r/m)
-    // 0x0C: or al,imm8 (I)
-    // 0x0D: or ax/eax/rax,imm16/32/32se (I) - (se: sign extended)
-    setOpc(0x08, IT_OR, VT_8,   parseMR, addBInstr, 0);
-    setOpc(0x09, IT_OR, VT_Def, parseMR, addBInstr, 0);
-    setOpc(0x0A, IT_OR, VT_8,   parseRM, addBInstr, 0);
-    setOpc(0x0B, IT_OR, VT_Def, parseRM, addBInstr, 0);
-    setOpc(0x0C, IT_OR, VT_8,   setO1RegA, parseI2, addBInstr);
-    setOpc(0x0D, IT_OR, VT_Def, setO1RegA, parseI2, addBInstr);
-
-    // 0x10: adc r/m8,r8 (MR, dst: r/m, src: r)
-    // 0x11: adc r/m,r 16/32/64 (MR, dst: r/m, src: r)
-    // 0x12: adc r8,r/m8 (RM, dst: r, src: r/m)
-    // 0x13: adc r,r/m 16/32/64 (RM, dst: r, src: r/m)
-    // 0x14: adc al,imm8 (I)
-    // 0x15: adc ax/eax/rax,imm16/32/32se (I) - (se: sign extended)
-    setOpc(0x10, IT_ADC, VT_8,   parseMR, addBInstr, 0);
-    setOpc(0x11, IT_ADC, VT_Def, parseMR, addBInstr, 0);
-    setOpc(0x12, IT_ADC, VT_8,   parseRM, addBInstr, 0);
-    setOpc(0x13, IT_ADC, VT_Def, parseRM, addBInstr, 0);
-    setOpc(0x14, IT_ADC, VT_8,   setO1RegA, parseI2, addBInstr);
-    setOpc(0x15, IT_ADC, VT_Def, setO1RegA, parseI2, addBInstr);
-
-    // 0x18: sbb r/m8,r8 (MR, dst: r/m, src: r)
-    // 0x19: sbb r/m,r 16/32/64 (MR, dst: r/m, src: r)
-    // 0x1A: sbb r8,r/m8 (RM, dst: r, src: r/m)
-    // 0x1B: sbb r,r/m 16/32/64 (RM, dst: r, src: r/m)
-    // 0x1C: sbb al,imm8 (I)
-    // 0x1D: sbb ax/eax/rax,imm16/32/32se (I) - (se: sign extended)
-    setOpc(0x18, IT_SBB, VT_8,   parseMR, addBInstr, 0);
-    setOpc(0x19, IT_SBB, VT_Def, parseMR, addBInstr, 0);
-    setOpc(0x1A, IT_SBB, VT_8,   parseRM, addBInstr, 0);
-    setOpc(0x1B, IT_SBB, VT_Def, parseRM, addBInstr, 0);
-    setOpc(0x1C, IT_SBB, VT_8,   setO1RegA, parseI2, addBInstr);
-    setOpc(0x1D, IT_SBB, VT_Def, setO1RegA, parseI2, addBInstr);
-
-    // 0x20: and r/m8,r8 (MR, dst: r/m, src: r)
-    // 0x21: and r/m,r 16/32/64 (MR, dst: r/m, src: r)
-    // 0x22: and r8,r/m8 (RM, dst: r, src: r/m)
-    // 0x23: and r,r/m 16/32/64 (RM, dst: r, src: r/m)
-    // 0x24: and al,imm8 (I)
-    // 0x25: and ax/eax/rax,imm16/32/32se (I) - (se: sign extended)
-    setOpc(0x20, IT_AND, VT_8,   parseMR, addBInstr, 0);
-    setOpc(0x21, IT_AND, VT_Def, parseMR, addBInstr, 0);
-    setOpc(0x22, IT_AND, VT_8,   parseRM, addBInstr, 0);
-    setOpc(0x23, IT_AND, VT_Def, parseRM, addBInstr, 0);
-    setOpc(0x24, IT_AND, VT_8,   setO1RegA, parseI2, addBInstr);
-    setOpc(0x25, IT_AND, VT_Def, setO1RegA, parseI2, addBInstr);
-
-    // 0x28: sub r/m8,r8 (MR, dst: r/m, src: r)
-    // 0x29: sub r/m,r 16/32/64 (MR, dst: r/m, src: r)
-    // 0x2A: sub r8,r/m8 (RM, dst: r, src: r/m)
-    // 0x2B: sub r,r/m 16/32/64 (RM, dst: r, src: r/m)
-    // 0x2C: sub al,imm8 (I)
-    // 0x2D: sub ax/eax/rax,imm16/32/32se (I) - (se: sign extended)
-    setOpc(0x28, IT_SUB, VT_8,   parseMR, addBInstr, 0);
-    setOpc(0x29, IT_SUB, VT_Def, parseMR, addBInstr, 0);
-    setOpc(0x2A, IT_SUB, VT_8,   parseRM, addBInstr, 0);
-    setOpc(0x2B, IT_SUB, VT_Def, parseRM, addBInstr, 0);
-    setOpc(0x2C, IT_SUB, VT_8,   setO1RegA, parseI2, addBInstr);
-    setOpc(0x2D, IT_SUB, VT_Def, setO1RegA, parseI2, addBInstr);
-
-    // 0x30: xor r/m8,r8 (MR, dst: r/m, src: r)
-    // 0x31: xor r/m,r 16/32/64 (MR, dst: r/m, src: r)
-    // 0x32: xor r8,r/m8 (RM, dst: r, src: r/m)
-    // 0x33: xor r,r/m 16/32/64 (RM, dst: r, src: r/m)
-    // 0x34: xor al,imm8 (I)
-    // 0x35: xor ax/eax/rax,imm16/32/32se (I) - (se: sign extended)
-    setOpc(0x30, IT_XOR, VT_8,   parseMR, addBInstr, 0);
-    setOpc(0x31, IT_XOR, VT_Def, parseMR, addBInstr, 0);
-    setOpc(0x32, IT_XOR, VT_8,   parseRM, addBInstr, 0);
-    setOpc(0x33, IT_XOR, VT_Def, parseRM, addBInstr, 0);
-    setOpc(0x34, IT_XOR, VT_8,   setO1RegA, parseI2, addBInstr);
-    setOpc(0x35, IT_XOR, VT_Def, setO1RegA, parseI2, addBInstr);
-
-    // 0x38: cmp r/m8,r8 (MR, dst: r/m, src: r)
-    // 0x39: cmp r/m,r 16/32/64 (MR, dst: r/m, src: r)
-    // 0x3A: cmp r8,r/m8 (RM, dst: r, src: r/m)
-    // 0x3B: cmp r,r/m 16/32/64 (RM, dst: r, src: r/m)
-    // 0x3C: cmp al,imm8 (I)
-    // 0x3D: cmp ax/eax/rax,imm16/32/32se (I) - (se: sign extended)
-    setOpc(0x38, IT_CMP, VT_8,   parseMR, addBInstr, 0);
-    setOpc(0x39, IT_CMP, VT_Def, parseMR, addBInstr, 0);
-    setOpc(0x3A, IT_CMP, VT_8,   parseRM, addBInstr, 0);
-    setOpc(0x3B, IT_CMP, VT_Def, parseRM, addBInstr, 0);
-    setOpc(0x3C, IT_CMP, VT_8,   setO1RegA, parseI2, addBInstr);
-    setOpc(0x3D, IT_CMP, VT_Def, setO1RegA, parseI2, addBInstr);
-
-    // 0x50-57: push r16/r64
-    setOpcH(0x50, decode_50);
-    setOpcH(0x51, decode_50);
-    setOpcH(0x52, decode_50);
-    setOpcH(0x53, decode_50);
-    setOpcH(0x54, decode_50);
-    setOpcH(0x55, decode_50);
-    setOpcH(0x56, decode_50);
-    setOpcH(0x57, decode_50);
-
-    // 0x58-5F: pop r16/r64
-    setOpcH(0x58, decode_58);
-    setOpcH(0x59, decode_58);
-    setOpcH(0x5A, decode_58);
-    setOpcH(0x5B, decode_58);
-    setOpcH(0x5C, decode_58);
-    setOpcH(0x5D, decode_58);
-    setOpcH(0x5E, decode_58);
-    setOpcH(0x5F, decode_58);
-
-     // movsx r64,r/m32
-    setOpcH(0x63, decode_63);
-
-    // 0x68: push imm32 (imm16 possible, but not generated by "as" - no test)
-    // 0x6A: push imm8
-    setOpc(0x68, IT_PUSH, VT_32, parseI1, addUInstr, 0);
-    setOpc(0x6A, IT_PUSH, VT_8,  parseI1, addUInstr, 0);
-
-    // 0x69: imul r,r/m16/32/64,imm16/32/32se (RMI)
-    // 0x6B: imul r,r/m16/32/64,imm8se (RMI)
-    setOpc(0x69, IT_IMUL, VT_Def,  parseRM, parseI3, addTInstr);
-    setOpc(0x6B, IT_IMUL, VT_Def,  parseRM, parseI3_8se, addTInstr);
-
-    // 0x70-7F: jcc rel8
-    setOpcH(0x70, decode_70);
-    setOpcH(0x71, decode_70);
-    setOpcH(0x72, decode_70);
-    setOpcH(0x73, decode_70);
-    setOpcH(0x74, decode_70);
-    setOpcH(0x75, decode_70);
-    setOpcH(0x76, decode_70);
-    setOpcH(0x77, decode_70);
-    setOpcH(0x78, decode_70);
-    setOpcH(0x79, decode_70);
-    setOpcH(0x7A, decode_70);
-    setOpcH(0x7B, decode_70);
-    setOpcH(0x7C, decode_70);
-    setOpcH(0x7D, decode_70);
-    setOpcH(0x7E, decode_70);
-    setOpcH(0x7F, decode_70);
-
-    // Immediate Grp 1
-    // 0x80: add/or/... r/m8,imm8 (MI)
-    // 0x81: add/or/... r/m16/32/64,imm16/32/32se (MI)
-    // 0x83: add/or/... r/m16/32/64,imm8se (MI)
-    setOpcG(0x80, 0, IT_ADD, VT_8,       parseMI, addBInstr, 0);
-    setOpcG(0x80, 1, IT_OR , VT_8,       parseMI, addBInstr, 0);
-    setOpcG(0x80, 2, IT_ADC, VT_8,       parseMI, addBInstr, 0);
-    setOpcG(0x80, 3, IT_SBB, VT_8,       parseMI, addBInstr, 0);
-    setOpcG(0x80, 4, IT_AND, VT_8,       parseMI, addBInstr, 0);
-    setOpcG(0x80, 5, IT_SUB, VT_8,       parseMI, addBInstr, 0);
-    setOpcG(0x80, 6, IT_XOR, VT_8,       parseMI, addBInstr, 0);
-    setOpcG(0x80, 7, IT_CMP, VT_8,       parseMI, addBInstr, 0);
-    setOpcG(0x81, 0, IT_ADD, VT_Def, parseMI, addBInstr, 0);
-    setOpcG(0x81, 1, IT_OR , VT_Def, parseMI, addBInstr, 0);
-    setOpcG(0x81, 2, IT_ADC, VT_Def, parseMI, addBInstr, 0);
-    setOpcG(0x81, 3, IT_SBB, VT_Def, parseMI, addBInstr, 0);
-    setOpcG(0x81, 4, IT_AND, VT_Def, parseMI, addBInstr, 0);
-    setOpcG(0x81, 5, IT_SUB, VT_Def, parseMI, addBInstr, 0);
-    setOpcG(0x81, 6, IT_XOR, VT_Def, parseMI, addBInstr, 0);
-    setOpcG(0x81, 7, IT_CMP, VT_Def, parseMI, addBInstr, 0);
-    setOpcG(0x83, 0, IT_ADD, VT_Def, parseMI_8se, addBInstr, 0);
-    setOpcG(0x83, 1, IT_OR , VT_Def, parseMI_8se, addBInstr, 0);
-    setOpcG(0x83, 2, IT_ADC, VT_Def, parseMI_8se, addBInstr, 0);
-    setOpcG(0x83, 3, IT_SBB, VT_Def, parseMI_8se, addBInstr, 0);
-    setOpcG(0x83, 4, IT_AND, VT_Def, parseMI_8se, addBInstr, 0);
-    setOpcG(0x83, 5, IT_SUB, VT_Def, parseMI_8se, addBInstr, 0);
-    setOpcG(0x83, 6, IT_XOR, VT_Def, parseMI_8se, addBInstr, 0);
-    setOpcG(0x83, 7, IT_CMP, VT_Def, parseMI_8se, addBInstr, 0);
-
-    // 0x84: test r/m8,r8 (MR) - r/m8 "and" r8, set SF, ZF, PF
-    // 0x85: test r/m,r16/32/64 (MR)
-    setOpc(0x84, IT_TEST, VT_8,   parseMR, addBInstr, 0);
-    setOpc(0x85, IT_TEST, VT_Def, parseMR, addBInstr, 0);
-
-    // 0x88: mov r/m8,r8 (MR)
-    // 0x89: mov r/m,r16/32/64 (MR)
-    // 0x8A: mov r8,r/m8,r8 (RM)
-    // 0x8B: mov r,r/m16/32/64 (RM)
-    setOpc(0x88, IT_MOV, VT_8,   parseMR, addBInstr, 0);
-    setOpc(0x89, IT_MOV, VT_Def, parseMR, addBInstr, 0);
-    setOpc(0x8A, IT_MOV, VT_8,   parseRM, addBInstr, 0);
-    setOpc(0x8B, IT_MOV, VT_Def, parseRM, addBInstr, 0);
-
-    // 0x8D: lea r16/32/64,m (RM)
-    setOpcH(0x8D, decode_8D);
-    // 0x8F/0: pop r/m 16/64 (M) Grp1A
-    setOpcGH(0x8F, 0, decode_8F_0);
-    // 0x90: nop
-    setOpc(0x90, IT_NOP, VT_None, addSInstr, 0, 0);
-
-    setOpcH(0x98, decode_98); // cltq
-    setOpcH(0x99, decode_99); // cqto
-
-    // 0xA8: test al,imm8
-    // 0xA9: test ax/eax/rax,imm16/32/32se
-    setOpc(0xA8, IT_TEST, VT_8,   setO1RegA, parseI2, addBInstr);
-    setOpc(0xA9, IT_TEST, VT_Def, setO1RegA, parseI2, addBInstr);
-
-    // 0xB0-B7: mov r8,imm8
-    // 0xB8-BF: mov r32/64,imm32/64
-    setOpcH(0xB0, decode_B0);
-    setOpcH(0xB1, decode_B0);
-    setOpcH(0xB2, decode_B0);
-    setOpcH(0xB3, decode_B0);
-    setOpcH(0xB4, decode_B0);
-    setOpcH(0xB5, decode_B0);
-    setOpcH(0xB6, decode_B0);
-    setOpcH(0xB7, decode_B0);
-    setOpcH(0xB8, decode_B0);
-    setOpcH(0xB9, decode_B0);
-    setOpcH(0xBA, decode_B0);
-    setOpcH(0xBB, decode_B0);
-    setOpcH(0xBC, decode_B0);
-    setOpcH(0xBD, decode_B0);
-    setOpcH(0xBE, decode_B0);
-    setOpcH(0xBF, decode_B0);
-
-    // 0xC0/C1: Grp1A
-    setOpcH(0xC0, decode_C0);
-    setOpcH(0xC1, decode_C1);
-
-    // 0xC3: ret
-    setOpc(0xC3, IT_RET, VT_None, addSInstr, reqExit, 0);
-
-    // 0xC6/C7: Grp 11
-    setOpcH(0xC6, decode_C6);
-    setOpcH(0xC7, decode_C7);
-
-    // 0xC9: leave ( = mov rbp,rsp + pop rbp)
-    setOpc(0xC9, IT_LEAVE, VT_None, addSInstr, 0, 0);
-
-    // 0xD0-D3: Grp1A
-    setOpcH(0xD0, decode_D0);
-    setOpcH(0xD1, decode_D1);
-    setOpcH(0xD2, decode_D2);
-    setOpcH(0xD3, decode_D3);
-
-    setOpcH(0xE8, decode_E8); // call rel32
-    setOpcH(0xE9, decode_E9); // jmp rel32
-    setOpcH(0xEB, decode_EB); // jmp rel8
-
-    // 0xF6/F7: Grp 3, 0xFE: Grp 4, 0xFE: Grp 5
-    setOpcH(0xF6, decode_F6);
-    setOpcH(0xF7, decode_F7);
-    setOpcH(0xFE, decode_FE);
-    setOpcH(0xFF, decode_FF);
-
-    // 0x0F10/No: movups xmm1,xmm2/m128 (RM)
-    // 0x0F10/66: movupd xmm1,xmm2/m128 (RM)
-    // 0x0F10/F3: movss xmm1,xmm2/m32 (RM)
-    // 0x0F10/F2: movsd xmm1,xmm2/m64 (RM)
-    setOpcP(0x0F10, PS_No, IT_MOVUPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F10, PS_66, IT_MOVUPD, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F10, PS_F3, IT_MOVSS,  VT_32,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F10, PS_F2, IT_MOVSD,  VT_64,  parseRMVV, addBInsImp, attach);
-
-    // 0x0F11/No: movups xmm1/m128,xmm2 (MR)
-    // 0x0F11/66: movupd xmm1/m128,xmm2 (MR)
-    // 0x0F11/F3: movss xmm1/m32,xmm2 (MR)
-    // 0x0F11/F2: movsd xmm1/m64,xmm2 (MR)
-    setOpcP(0x0F11, PS_No, IT_MOVUPS, VT_128, parseMRVV, addBInsImp, attach);
-    setOpcP(0x0F11, PS_66, IT_MOVUPD, VT_128, parseMRVV, addBInsImp, attach);
-    setOpcP(0x0F11, PS_F3, IT_MOVSS,  VT_32,  parseMRVV, addBInsImp, attach);
-    setOpcP(0x0F11, PS_F2, IT_MOVSD,  VT_64,  parseMRVV, addBInsImp, attach);
-
-    setOpcH(0x0F12, decode0F_12);
-    setOpcH(0x0F13, decode0F_13);
-    setOpcH(0x0F14, decode0F_14);
-    setOpcH(0x0F15, decode0F_15);
-    setOpcH(0x0F16, decode0F_16);
-    setOpcH(0x0F17, decode0F_17);
-    setOpcH(0x0F1F, decode0F_1F);
-    setOpcH(0x0F28, decode0F_28);
-    setOpcH(0x0F29, decode0F_29);
-    setOpcH(0x0F2E, decode0F_2E);
-
-    // 0x0F40-0x0F4F: cmovcc r,r/m 16/32/64
-    setOpcH(0x0F40, decode0F_40);
-    setOpcH(0x0F41, decode0F_40);
-    setOpcH(0x0F42, decode0F_40);
-    setOpcH(0x0F43, decode0F_40);
-    setOpcH(0x0F44, decode0F_40);
-    setOpcH(0x0F45, decode0F_40);
-    setOpcH(0x0F46, decode0F_40);
-    setOpcH(0x0F47, decode0F_40);
-    setOpcH(0x0F48, decode0F_40);
-    setOpcH(0x0F49, decode0F_40);
-    setOpcH(0x0F4A, decode0F_40);
-    setOpcH(0x0F4B, decode0F_40);
-    setOpcH(0x0F4C, decode0F_40);
-    setOpcH(0x0F4D, decode0F_40);
-    setOpcH(0x0F4E, decode0F_40);
-    setOpcH(0x0F4F, decode0F_40);
-
-    // 0x0F51/F3: sqrtss xmm1,xmm2/m32 (RM)
-    // 0x0F51/F2: sqrtsd xmm1,xmm2/m64 (RM)
-    // 0x0F51/No: sqrtps xmm1,xmm2/m128 (RM)
-    // 0x0F51/66: sqrtpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F51, PS_F3, IT_SQRTSS, VT_32,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F51, PS_F2, IT_SQRTSD, VT_64,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F51, PS_No, IT_SQRTPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F51, PS_66, IT_SQRTPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F52/F3: rsqrtss xmm1,xmm2/m32 (RM)
-    // 0x0F52/No: rsqrtps xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F52, PS_F3, IT_RSQRTSS, VT_32,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F52, PS_No, IT_RSQRTPS, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F53/F3: rcpss xmm1,xmm2/m32 (RM)
-    // 0x0F53/No: rcpps xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F53, PS_F3, IT_RCPSS, VT_32,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F53, PS_No, IT_RCPPS, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F54/No: andps xmm1,xmm2/m128 (RM)
-    // 0x0F54/66: andpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F54, PS_No, IT_ANDPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F54, PS_66, IT_ANDPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F55/No: andnps xmm1,xmm2/m128 (RM)
-    // 0x0F55/66: andnpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F55, PS_No, IT_ANDNPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F55, PS_66, IT_ANDNPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F56/No: orps xmm1,xmm2/m128 (RM)
-    // 0x0F56/66: orpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F56, PS_No, IT_ORPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F56, PS_66, IT_ORPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F57/No: xorps xmm1,xmm2/m128 (RM)
-    // 0x0F57/66: xorpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F57, PS_No, IT_XORPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F57, PS_66, IT_XORPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F58/F3: addss xmm1,xmm2/m32 (RM)
-    // 0x0F58/F2: addsd xmm1,xmm2/m64 (RM)
-    // 0x0F58/No: addps xmm1,xmm2/m128 (RM)
-    // 0x0F58/66: addpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F58, PS_F3, IT_ADDSS, VT_32,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F58, PS_F2, IT_ADDSD, VT_64,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F58, PS_No, IT_ADDPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F58, PS_66, IT_ADDPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F59/F3: mulss xmm1,xmm2/m32 (RM)
-    // 0x0F59/F2: mulsd xmm1,xmm2/m64 (RM)
-    // 0x0F59/No: mulps xmm1,xmm2/m128 (RM)
-    // 0x0F59/66: mulpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F59, PS_F3, IT_MULSS, VT_32,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F59, PS_F2, IT_MULSD, VT_64,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F59, PS_No, IT_MULPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F59, PS_66, IT_MULPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F5C/F3: subss xmm1,xmm2/m32 (RM)
-    // 0x0F5C/F2: subsd xmm1,xmm2/m64 (RM)
-    // 0x0F5C/No: subps xmm1,xmm2/m128 (RM)
-    // 0x0F5C/66: subpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F5C, PS_F3, IT_SUBSS, VT_32,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5C, PS_F2, IT_SUBSD, VT_64,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5C, PS_No, IT_SUBPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5C, PS_66, IT_SUBPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F5D/F3: minss xmm1,xmm2/m32 (RM)
-    // 0x0F5D/F2: minsd xmm1,xmm2/m64 (RM)
-    // 0x0F5D/No: minps xmm1,xmm2/m128 (RM)
-    // 0x0F5D/66: minpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F5D, PS_F3, IT_MINSS, VT_32,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5D, PS_F2, IT_MINSD, VT_64,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5D, PS_No, IT_MINPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5D, PS_66, IT_MINPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F5E/F3: divss xmm1,xmm2/m32 (RM)
-    // 0x0F5E/F2: divsd xmm1,xmm2/m64 (RM)
-    // 0x0F5E/No: divps xmm1,xmm2/m128 (RM)
-    // 0x0F5E/66: divpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F5E, PS_F3, IT_DIVSS, VT_32,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5E, PS_F2, IT_DIVSD, VT_64,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5E, PS_No, IT_DIVPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5E, PS_66, IT_DIVPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F5F/F3: maxss xmm1,xmm2/m32 (RM)
-    // 0x0F5F/F2: maxsd xmm1,xmm2/m64 (RM)
-    // 0x0F5F/No: maxps xmm1,xmm2/m128 (RM)
-    // 0x0F5F/66: maxpd xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F5F, PS_F3, IT_MAXSS, VT_32,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5F, PS_F2, IT_MAXSD, VT_64,  parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5F, PS_No, IT_MAXPS, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F5F, PS_66, IT_MAXPD, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F6E/66: movd/q xmm,r/m 32/64 (RM)
-    setOpcPH(0x0F6E, PS_66, decode0F_6E_P66);
-
-    // 0x0F6F/F3: movdqu xmm1,xmm2/m128 (RM)
-    // 0x0F6F/66: movdqa xmm1,xmm2/m128 (RM)
-    // 0x0F6F/No: movq mm1,mm2/m64 (RM)
-    setOpcP(0x0F6F, PS_F3, IT_MOVDQU, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F6F, PS_66, IT_MOVDQA, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F6F, PS_No, IT_MOVQ,   VT_64,  parseRMVV, addBInsImp, attach);
-
-    // 0x0F74/No: pcmpeqb mm,mm/m64 (RM)
-    // 0x0F74/66: pcmpeqb mm,mm/m128 (RM)
-    //setOpcP(0x0F74, PS_No, IT_PCMPEQB, VT_64,  parseRMVV, addBInsImp, attach);
-    //setOpcP(0x0F74, PS_66, IT_PCMPEQB, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcH(0x0F74, decode0F_74);
-
-    // 0x0F7C/66: haddpd xmm1,xmm2/m128 (RM)
-    // 0x0F7C/F2: haddps xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F7C, PS_66, IT_HADDPD, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F7C, PS_F2, IT_HADDPS, VT_128, parseRMVV, addBInsImp, attach);
-
-    // 0x0F7D/66: hsubpd xmm1,xmm2/m128 (RM)
-    // 0x0F7D/F2: hsubps xmm1,xmm2/m128 (RM)
-    setOpcP(0x0F7D, PS_66, IT_HSUBPD, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0F7D, PS_F2, IT_HSUBPS, VT_128, parseRMVV, addBInsImp, attach);
-
-    setOpcH(0x0F7E, decode0F_7E);
-    setOpcH(0x0F7F, decode0F_7F);
-
-    // 0x0F80-0F8F: jcc rel32
-    setOpcH(0x0F80, decode0F_80);
-    setOpcH(0x0F81, decode0F_80);
-    setOpcH(0x0F82, decode0F_80);
-    setOpcH(0x0F83, decode0F_80);
-    setOpcH(0x0F84, decode0F_80);
-    setOpcH(0x0F85, decode0F_80);
-    setOpcH(0x0F86, decode0F_80);
-    setOpcH(0x0F87, decode0F_80);
-    setOpcH(0x0F88, decode0F_80);
-    setOpcH(0x0F89, decode0F_80);
-    setOpcH(0x0F8A, decode0F_80);
-    setOpcH(0x0F8B, decode0F_80);
-    setOpcH(0x0F8C, decode0F_80);
-    setOpcH(0x0F8D, decode0F_80);
-    setOpcH(0x0F8E, decode0F_80);
-    setOpcH(0x0F8F, decode0F_80);
-
-    // 0x0FAF: imul r,rm16/32/64 (RM), signed mul (d/q)word by r/m
-    setOpc(0x0FAF, IT_IMUL, VT_Def, parseRM, addBInstr, 0);
-
-    setOpcH(0x0FB6, decode0F_B6); // movzbl r16/32/64,r/m8 (RM)
-    setOpcH(0x0FB7, decode0F_B7); // movzbl r32/64,r/m16 (RM)
-
-    // 0x0FBC: bsf r,r/m 16/32/64 (RM): bit scan forward
-    setOpc(0x0FBC, IT_BSF, VT_Def, parseRM, addBInstr, 0);
-
-    setOpcH(0x0FBE, decode0F_BE); // movsx r16/32/64,r/m8 (RM)
-    setOpcH(0x0FBF, decode0F_BF); // movsx r32/64,r/m16 (RM)
-
-    // 0x0FD0/66: addsubpd xmm1,xmm2/m128 (RM)
-    // 0x0FD0/F2: addsubps xmm1,xmm2/m128 (RM)
-    setOpcP(0x0FD0, PS_66, IT_ADDSUBPD, VT_128, parseRMVV, addBInsImp, attach);
-    setOpcP(0x0FD0, PS_F2, IT_ADDSUBPS, VT_128, parseRMVV, addBInsImp, attach);
-
-    setOpcH(0x0FD4, decode0F_D4); // paddq xmm1,xmm2/m 64/128 (RM)
-    setOpcH(0x0FD6, decode0F_D6); // movq xmm2/m64,xmm1 (MR)
-    setOpcH(0x0FD7, decode0F_D7); // pmovmskb r,xmm 64/128 (RM)
-    setOpcH(0x0FDA, decode0F_DA); // pminub xmm,xmm/m 64/128 (RM)
-    setOpcH(0x0FEF, decode0F_EF); // pxor xmm1,xmm2/m 64/128 (RM)
-}
-
-// decode the basic block starting at f (automatically triggered by emulator)
-DBB* dbrew_decode(Rewriter* r, uint64_t f)
-{
-    DContext cxt;
-    int i, old_icount, opc;
-    DBB* dbb;
-
-    if (f == 0) return 0; // nothing to decode
-    if (r->decBB == 0) initRewriter(r);
-    initDecodeTables();
-
-    // already decoded?
-    for(i = 0; i < r->decBBCount; i++)
-        if (r->decBB[i].addr == f) return &(r->decBB[i]);
+    int old_icount = r->decInstrCount;
 
     // start decoding of new BB beginning at f
     assert(r->decBBCount < r->decBBCapacity);
-    dbb = &(r->decBB[r->decBBCount]);
-    r->decBBCount++;
+    DBB* dbb = &r->decBB[r->decBBCount++];
     dbb->addr = f;
     dbb->fc = config_find_function(r, f);
     dbb->count = 0;
     dbb->size = 0;
     dbb->instr = r->decInstr + r->decInstrCount;
-    old_icount = r->decInstrCount;
 
     if (r->showDecoding)
         printf("Decoding BB %s ...\n", prettyAddress(f, dbb->fc));
 
-    initDContext(&cxt, r, dbb);
+    uint64_t offset = 0;
+    bool terminate = false;
+    do
+    {
+        int newOffset = dbrew_decode_instruction((uint8_t*) f + offset, r, &terminate);
 
-    while(!cxt.exit) {
-        decodePrefixes(&cxt);
+        if (newOffset < 0)
+            break;
 
-        // parse opcode by running handlers defined in opcode tables
-        opc = cxt.f[cxt.off++];
-        cxt.opc1 = opc;
-        if (opc == 0x0F) {
-            // opcode starting with 0x0F
-            opc = cxt.f[cxt.off++];
-            cxt.opc2 = opc;
-            processOpc(&(opcTable0F[opc]), &cxt);
-        }
-        else
-          processOpc(&(opcTable[opc]), &cxt);
-         if (isErrorSet(&(cxt.error.e))) {
-             // current "fall-back": output error, stop decoding
-             logError(&(cxt.error.e), (char*) "Stopped decoding");
-             break;
-         }
+        offset += newOffset;
     }
+    while (!terminate);
 
     assert(dbb->addr == dbb->instr->addr);
     dbb->count = r->decInstrCount - old_icount;
-    dbb->size = cxt.off;
+    dbb->size = offset;
 
     if (r->showDecoding)
         dbrew_print_decoded(dbb);
 
     return dbb;
 }
-

--- a/src/generate.c
+++ b/src/generate.c
@@ -1317,99 +1317,98 @@ void generate(Rewriter* r, CBB* cbb)
 
         buf = reserveCodeStorage(r->cs, 15);
 
-        if (instr->ptLen > 0) {
-            used = genPassThrough(buf, instr);
-        }
-        else {
-            switch(instr->type) {
-            case IT_ADD:
-                used = genAdd(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_CLTQ:
-                used = genCltq(buf, instr->vtype);
-                break;
-            case IT_CQTO:
-                used = genCqto(buf, instr->vtype);
-                break;
-            case IT_CMP:
-                used = genCmp(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_DEC:
-                used = genDec(buf, &(instr->dst));
-                break;
-            case IT_IMUL:
-                used = genIMul(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_IDIV1:
-                used = genIDiv1(buf, &(instr->dst));
-                break;
-            case IT_INC:
-                used = genInc(buf, &(instr->dst));
-                break;
-            case IT_XOR:
-                used = genXor(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_OR:
-                used = genOr(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_AND:
-                used = genAnd(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_SHL:
-                used = genShl(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_SHR:
-                used = genShr(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_SAR:
-                used = genSar(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_LEA:
-                used = genLea(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_MOV:
-            case IT_MOVSX: // converting move
-                used = genMov(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_CMOVO:
-            case IT_CMOVNO:
-            case IT_CMOVC:
-            case IT_CMOVNC:
-            case IT_CMOVZ:
-            case IT_CMOVNZ:
-            case IT_CMOVBE:
-            case IT_CMOVA:
-            case IT_CMOVS:
-            case IT_CMOVNS:
-            case IT_CMOVP:
-            case IT_CMOVNP:
-            case IT_CMOVL:
-            case IT_CMOVGE:
-            case IT_CMOVLE:
-            case IT_CMOVG:
-                used = genCMov(buf, instr->type, &(instr->src), &(instr->dst));
-                break;
-            case IT_POP:
-                used = genPop(buf, &(instr->dst));
-                break;
-            case IT_PUSH:
-                used = genPush(buf, &(instr->dst));
-                break;
-            case IT_RET:
-                used = genRet(buf);
-                break;
-            case IT_SUB:
-                used = genSub(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_TEST:
-                used = genTest(buf, &(instr->src), &(instr->dst));
-                break;
-            case IT_HINT_CALL:
-            case IT_HINT_RET:
-                used = 0;
-                break;
-            default: assert(0);
-            }
+        switch(instr->type) {
+        case IT_ADD:
+            used = genAdd(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_CLTQ:
+            used = genCltq(buf, instr->vtype);
+            break;
+        case IT_CQTO:
+            used = genCqto(buf, instr->vtype);
+            break;
+        case IT_CMP:
+            used = genCmp(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_DEC:
+            used = genDec(buf, &(instr->dst));
+            break;
+        case IT_IMUL:
+            used = genIMul(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_IDIV1:
+            used = genIDiv1(buf, &(instr->dst));
+            break;
+        case IT_INC:
+            used = genInc(buf, &(instr->dst));
+            break;
+        case IT_XOR:
+            used = genXor(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_OR:
+            used = genOr(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_AND:
+            used = genAnd(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_SHL:
+            used = genShl(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_SHR:
+            used = genShr(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_SAR:
+            used = genSar(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_LEA:
+            used = genLea(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_MOV:
+        case IT_MOVSX: // converting move
+            used = genMov(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_CMOVO:
+        case IT_CMOVNO:
+        case IT_CMOVC:
+        case IT_CMOVNC:
+        case IT_CMOVZ:
+        case IT_CMOVNZ:
+        case IT_CMOVBE:
+        case IT_CMOVA:
+        case IT_CMOVS:
+        case IT_CMOVNS:
+        case IT_CMOVP:
+        case IT_CMOVNP:
+        case IT_CMOVL:
+        case IT_CMOVGE:
+        case IT_CMOVLE:
+        case IT_CMOVG:
+            used = genCMov(buf, instr->type, &(instr->src), &(instr->dst));
+            break;
+        case IT_POP:
+            used = genPop(buf, &(instr->dst));
+            break;
+        case IT_PUSH:
+            used = genPush(buf, &(instr->dst));
+            break;
+        case IT_RET:
+            used = genRet(buf);
+            break;
+        case IT_SUB:
+            used = genSub(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_TEST:
+            used = genTest(buf, &(instr->src), &(instr->dst));
+            break;
+        case IT_HINT_CALL:
+        case IT_HINT_RET:
+            used = 0;
+            break;
+        default:
+            if (instr->ptLen > 0)
+                used = genPassThrough(buf, instr);
+            else
+                assert(0);
         }
         assert(used < 15);
 

--- a/src/instr-descriptors.c
+++ b/src/instr-descriptors.c
@@ -1,0 +1,458 @@
+/**
+ * This file is part of DBrew, the dynamic binary rewriting library.
+ *
+ * (c) 2015-2016, Josef Weidendorfer <josef.weidendorfer@gmx.de>
+ *
+ * DBrew is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License (LGPL)
+ * as published by the Free Software Foundation, either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * DBrew is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DBrew.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "instr-descriptors.h"
+
+#include "instr.h"
+
+
+// Operand types: vector or general-purpose for operand 1 and 2
+#define RT_GG 0
+#define RT_GV 1
+#define RT_VG 2
+#define RT_VV 3
+
+#define INSTR_M(opcCount,opc1,opc2,opc3,prefixes,regtype,vto1,vti,digit,it) { OE_M, opcCount, {opc1, opc2, opc3}, prefixes, regtype, vto1, 0, vti, digit, 0, false, it, NULL },
+#define INSTR_M1(opcCount,opc1,opc2,opc3,prefixes,regtype,vto1,vti,digit,it) { OE_M1, opcCount, {opc1, opc2, opc3}, prefixes, regtype, vto1, 0, vti, digit, 0, false, it, NULL },
+#define INSTR_Mcc(opcCount,opc1,opc2,opc3,prefixes,regtype,vto1,vti,digit,it) { OE_M, opcCount, {opc1, opc2, opc3}, prefixes, regtype, vto1, 0, vti, digit, 0, true, it, NULL },
+#define INSTR_MC(opcCount,opc1,opc2,opc3,prefixes,regtype,vto1,vti,digit,it) { OE_MC, opcCount, {opc1, opc2, opc3}, prefixes, regtype, vto1, 0, vti, digit, 0, true, it, NULL },
+#define INSTR_MI(opcCount,opc1,opc2,opc3,prefixes,regtype,vto1,vti,digit,immsize,it) { OE_MI, opcCount, {opc1, opc2, opc3}, prefixes, regtype, vto1, 0, vti, digit, immsize, false, it, NULL },
+#define INSTR_MR(opcCount,opc1,opc2,opc3,prefixes,regtype,vto1,vto2,vti,it) { OE_MR, opcCount, {opc1, opc2, opc3}, prefixes, regtype, vto1, vto2, vti, -1, 0, false, it, NULL },
+#define INSTR_MRI(opcCount,opc1,opc2,opc3,prefixes,regtype,vto1,vto2,vti,immsize,it) { OE_MRI, opcCount, {opc1, opc2, opc3}, prefixes, regtype, vto1, vto2, vti, -1, immsize, false, it, NULL },
+#define INSTR_RM(opcCount,opc1,opc2,opc3,prefixes,regtype,vto1,vto2,vti,it) { OE_RM, opcCount, {opc1, opc2, opc3}, prefixes, regtype, vto1, vto2, vti, -1, 0, false, it, NULL },
+#define INSTR_RMcc(opcCount,opc1,opc2,opc3,prefixes,regtype,vto1,vto2,vti,it) { OE_RM, opcCount, {opc1, opc2, opc3}, prefixes, regtype, vto1, vto2, vti, -1, 0, true, it, NULL },
+#define INSTR_RMI(opcCount,opc1,opc2,opc3,prefixes,regtype,vto1,vto2,vti,immsize,it) { OE_RMI, opcCount, {opc1, opc2, opc3}, prefixes, regtype, vto1, vto2, vti, -1, immsize, false, it, NULL },
+#define INSTR_O(opcCount,opc1,opc2,opc3,prefixes,vti,it) { OE_O, opcCount, {opc1, opc2, opc3}, prefixes, RT_GG, 0, 0, vti, -1, 0, false, it, NULL },
+#define INSTR_OI(opcCount,opc1,opc2,opc3,prefixes,vti,immsize,it) { OE_OI, opcCount, {opc1, opc2, opc3}, prefixes, RT_GG, 0, 0, vti, -1, immsize, false, it, NULL },
+#define INSTR_I(opcCount,opc1,opc2,opc3,prefixes,vti,immsize,it) { OE_I, opcCount, {opc1, opc2, opc3}, prefixes, RT_GG, 0, 0, vti, -1, immsize, false, it, NULL },
+#define INSTR_IA(opcCount,opc1,opc2,opc3,prefixes,vti,immsize,it) { OE_IA, opcCount, {opc1, opc2, opc3}, prefixes, RT_GG, 0, 0, vti, -1, immsize, false, it, NULL },
+#define INSTR_D(opcCount,opc1,opc2,opc3,prefixes,vti,immsize,it) { OE_D, opcCount, {opc1, opc2, opc3}, prefixes, RT_GG, 0, 0, vti, -1, immsize, false, it, NULL },
+#define INSTR_Dcc(opcCount,opc1,opc2,opc3,prefixes,vti,immsize,it) { OE_D, opcCount, {opc1, opc2, opc3}, prefixes, RT_GG, 0, 0, vti, -1, immsize, true, it, NULL },
+#define INSTR_NP(opcCount,opc1,opc2,opc3,prefixes,vti,it) { OE_NP, opcCount, {opc1, opc2, opc3}, prefixes, RT_GG, 0, 0, vti, -1, 0, false, it, NULL },
+#define INSTR_fn(opcCount,opc1,opc2,opc3,prefixes,handler) { OE_None, opcCount, {opc1, opc2, opc3}, prefixes, RT_GG, 0, 0, VT_None, -1, 0, false, IT_None, handler },
+#define INSTR1_M(opc1,...) INSTR_M(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_M1(opc1,...) INSTR_M1(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_MI(opc1,...) INSTR_MI(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_MC(opc1,...) INSTR_MC(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_MR(opc1,...) INSTR_MR(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_MRI(opc1,...) INSTR_MRI(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_RM(opc1,...) INSTR_RM(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_RMI(opc1,...) INSTR_RMI(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_O(opc1,...) INSTR_O(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_OI(opc1,...) INSTR_OI(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_I(opc1,...) INSTR_I(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_IA(opc1,...) INSTR_IA(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_D(opc1,...) INSTR_D(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_Dcc(opc1,...) INSTR_Dcc(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_NP(opc1,...) INSTR_NP(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR1_fn(opc1,...) INSTR_fn(1,opc1,-1,-1,__VA_ARGS__)
+#define INSTR2_M(opc2,...) INSTR_M(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_Mcc(opc2,...) INSTR_Mcc(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_MI(opc2,...) INSTR_MI(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_MR(opc2,...) INSTR_MR(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_MRI(opc2,...) INSTR_MRI(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_RM(opc2,...) INSTR_RM(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_RMcc(opc2,...) INSTR_RMcc(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_RMI(opc2,...) INSTR_RMI(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_O(opc2,...) INSTR_O(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_OI(opc2,...) INSTR_OI(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_I(opc2,...) INSTR_I(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_D(opc2,...) INSTR_D(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_Dcc(opc2,...) INSTR_Dcc(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_NP(opc2,...) INSTR_NP(2,0x0F,opc2,-1,__VA_ARGS__)
+#define INSTR2_fn(opc2,...) INSTR_fn(2,0x0F,opc2,-1,__VA_ARGS__)
+// Later, if we want instructions with 0f38, 0f3a
+// #define INSTR3_M(opc2,opc3,...) INSTR_M(3,0x0F,opc2,opc3,__VA_ARGS__)
+// #define INSTR3_MI(opc2,opc3,...) INSTR_MI(3,0x0F,opc2,opc3,__VA_ARGS__)
+// #define INSTR3_MR(opc2,opc3,...) INSTR_MR(3,0x0F,opc2,opc3,__VA_ARGS__)
+// #define INSTR3_MRI(opc2,opc3,...) INSTR_MRI(3,0x0F,opc2,opc3,__VA_ARGS__)
+// #define INSTR3_RM(opc2,opc3,...) INSTR_RM(3,0x0F,opc2,opc3,__VA_ARGS__)
+// #define INSTR3_RMI(opc2,opc3,...) INSTR_RMI(3,0x0F,opc2,opc3,__VA_ARGS__)
+// #define INSTR3_O(opc2,opc3,...) INSTR_O(3,0x0F,opc2,opc3,__VA_ARGS__)
+// #define INSTR3_I(opc2,opc3,...) INSTR_I(3,0x0F,opc2,opc3,__VA_ARGS__)
+// #define INSTR3_D(opc2,opc3,...) INSTR_D(3,0x0F,opc2,opc3,__VA_ARGS__)
+// #define INSTR3_NP(opc2,opc3,...) INSTR_NP(3,0x0F,opc2,opc3,__VA_ARGS__)
+
+// An example how to use custom decoding functions.
+// static
+// int
+// decode_nop_simple(uint8_t* fp, Instr* instr, const InstrDescriptor* desc, int rex, OpSegOverride segment)
+// {
+//     initSimpleInstr(instr, IT_NOP);
+//     (void) fp;
+//     (void) desc;
+//     (void) rex;
+//     (void) segment;
+//     return 0;
+// }
+
+const InstrDescriptor instrDescriptors[] = {
+INSTR1_MR(0x00, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_ADD)
+INSTR1_MR(0x01, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_ADD)
+INSTR1_MR(0x01, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_ADD)
+INSTR1_RM(0x02, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_ADD)
+INSTR1_RM(0x03, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_ADD)
+INSTR1_RM(0x03, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_ADD)
+INSTR1_IA(0x04, PS_None, VT_8, 8, IT_ADD)
+INSTR1_IA(0x05, PS_66, VT_16, 16, IT_ADD)
+INSTR1_IA(0x05, PS_None, VT_None, 32, IT_ADD)
+INSTR1_MR(0x08, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_OR)
+INSTR1_MR(0x09, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_OR)
+INSTR1_MR(0x09, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_OR)
+INSTR1_RM(0x0A, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_OR)
+INSTR1_RM(0x0B, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_OR)
+INSTR1_RM(0x0B, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_OR)
+INSTR1_IA(0x0C, PS_None, VT_8, 8, IT_OR)
+INSTR1_IA(0x0D, PS_66, VT_16, 16, IT_OR)
+INSTR1_IA(0x0D, PS_None, VT_None, 32, IT_OR)
+
+INSTR1_MR(0x10, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_ADC)
+INSTR1_MR(0x11, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_ADC)
+INSTR1_MR(0x11, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_ADC)
+INSTR1_RM(0x12, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_ADC)
+INSTR1_RM(0x13, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_ADC)
+INSTR1_RM(0x13, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_ADC)
+INSTR1_IA(0x14, PS_None, VT_8, 8, IT_ADC)
+INSTR1_IA(0x15, PS_66, VT_16, 16, IT_ADC)
+INSTR1_IA(0x15, PS_None, VT_None, 32, IT_ADC)
+INSTR1_MR(0x18, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_SBB)
+INSTR1_MR(0x19, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_SBB)
+INSTR1_MR(0x19, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_SBB)
+INSTR1_RM(0x1A, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_SBB)
+INSTR1_RM(0x1B, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_SBB)
+INSTR1_RM(0x1B, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_SBB)
+INSTR1_IA(0x1C, PS_None, VT_8, 8, IT_SBB)
+INSTR1_IA(0x1D, PS_66, VT_16, 16, IT_SBB)
+INSTR1_IA(0x1D, PS_None, VT_None, 32, IT_SBB)
+
+INSTR1_MR(0x20, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_AND)
+INSTR1_MR(0x21, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_AND)
+INSTR1_MR(0x21, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_AND)
+INSTR1_RM(0x22, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_AND)
+INSTR1_RM(0x23, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_AND)
+INSTR1_RM(0x23, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_AND)
+INSTR1_IA(0x24, PS_None, VT_8, 8, IT_AND)
+INSTR1_IA(0x25, PS_66, VT_16, 16, IT_AND)
+INSTR1_IA(0x25, PS_None, VT_None, 32, IT_AND)
+INSTR1_MR(0x28, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_SUB)
+INSTR1_MR(0x29, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_SUB)
+INSTR1_MR(0x29, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_SUB)
+INSTR1_RM(0x2A, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_SUB)
+INSTR1_RM(0x2B, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_SUB)
+INSTR1_RM(0x2B, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_SUB)
+INSTR1_IA(0x2C, PS_None, VT_8, 8, IT_SUB)
+INSTR1_IA(0x2D, PS_66, VT_16, 16, IT_SUB)
+INSTR1_IA(0x2D, PS_None, VT_None, 32, IT_SUB)
+
+INSTR1_MR(0x30, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_XOR)
+INSTR1_MR(0x31, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_XOR)
+INSTR1_MR(0x31, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_XOR)
+INSTR1_RM(0x32, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_XOR)
+INSTR1_RM(0x33, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_XOR)
+INSTR1_RM(0x33, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_XOR)
+INSTR1_IA(0x34, PS_None, VT_8, 8, IT_XOR)
+INSTR1_IA(0x35, PS_66, VT_16, 16, IT_XOR)
+INSTR1_IA(0x35, PS_None, VT_None, 32, IT_XOR)
+INSTR1_MR(0x38, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_CMP)
+INSTR1_MR(0x39, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_CMP)
+INSTR1_MR(0x39, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_CMP)
+INSTR1_RM(0x3A, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_CMP)
+INSTR1_RM(0x3B, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_CMP)
+INSTR1_RM(0x3B, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_CMP)
+INSTR1_IA(0x3C, PS_None, VT_8, 8, IT_CMP)
+INSTR1_IA(0x3D, PS_66, VT_16, 16, IT_CMP)
+INSTR1_IA(0x3D, PS_None, VT_None, 32, IT_CMP)
+
+INSTR1_O (0x50, PS_None, VT_64, IT_PUSH)
+INSTR1_O (0x50, PS_66, VT_16, IT_PUSH)
+INSTR1_O (0x58, PS_None, VT_64, IT_POP)
+INSTR1_O (0x58, PS_66, VT_16, IT_POP)
+
+INSTR1_RM(0x63, PS_None, RT_GG, VT_None, VT_32, VT_None, IT_MOVSX)
+INSTR1_I (0x68, PS_None, VT_32, 32, IT_PUSH)
+INSTR1_RMI(0x69, PS_None, RT_GG, VT_None, VT_None, VT_None, 32, IT_IMUL)
+INSTR1_RMI(0x69, PS_66, RT_GG, VT_16, VT_16, VT_16, 16, IT_IMUL)
+INSTR1_I (0x6A, PS_None, VT_8, 8, IT_PUSH)
+INSTR1_RMI(0x6B, PS_None, RT_GG, VT_None, VT_None, VT_None, 8, IT_IMUL)
+INSTR1_RMI(0x6B, PS_66, RT_GG, VT_16, VT_16, VT_16, 8, IT_IMUL)
+
+INSTR1_Dcc(0x70, PS_None, VT_8, 8, IT_JO)
+
+// Immediate Group 1, Intel Vol. 2C A-8
+INSTR1_MI(0x80, PS_None, RT_GG, VT_8, VT_8, 0, 8, IT_ADD)
+INSTR1_MI(0x80, PS_None, RT_GG, VT_8, VT_8, 1, 8, IT_OR)
+INSTR1_MI(0x80, PS_None, RT_GG, VT_8, VT_8, 2, 8, IT_ADC)
+INSTR1_MI(0x80, PS_None, RT_GG, VT_8, VT_8, 3, 8, IT_SBB)
+INSTR1_MI(0x80, PS_None, RT_GG, VT_8, VT_8, 4, 8, IT_AND)
+INSTR1_MI(0x80, PS_None, RT_GG, VT_8, VT_8, 5, 8, IT_SUB)
+INSTR1_MI(0x80, PS_None, RT_GG, VT_8, VT_8, 6, 8, IT_XOR)
+INSTR1_MI(0x80, PS_None, RT_GG, VT_8, VT_8, 7, 8, IT_CMP)
+INSTR1_MI(0x81, PS_66, RT_GG, VT_16, VT_16, 0, 16, IT_ADD)
+INSTR1_MI(0x81, PS_None, RT_GG, VT_None, VT_None, 0, 32, IT_ADD)
+INSTR1_MI(0x81, PS_66, RT_GG, VT_16, VT_16, 1, 16, IT_OR)
+INSTR1_MI(0x81, PS_None, RT_GG, VT_None, VT_None, 1, 32, IT_OR)
+INSTR1_MI(0x81, PS_66, RT_GG, VT_16, VT_16, 2, 16, IT_ADC)
+INSTR1_MI(0x81, PS_None, RT_GG, VT_None, VT_None, 2, 32, IT_ADC)
+INSTR1_MI(0x81, PS_66, RT_GG, VT_16, VT_16, 3, 16, IT_SBB)
+INSTR1_MI(0x81, PS_None, RT_GG, VT_None, VT_None, 3, 32, IT_SBB)
+INSTR1_MI(0x81, PS_66, RT_GG, VT_16, VT_16, 4, 16, IT_AND)
+INSTR1_MI(0x81, PS_None, RT_GG, VT_None, VT_None, 4, 32, IT_AND)
+INSTR1_MI(0x81, PS_66, RT_GG, VT_16, VT_16, 5, 16, IT_SUB)
+INSTR1_MI(0x81, PS_None, RT_GG, VT_None, VT_None, 5, 32, IT_SUB)
+INSTR1_MI(0x81, PS_66, RT_GG, VT_16, VT_16, 6, 16, IT_XOR)
+INSTR1_MI(0x81, PS_None, RT_GG, VT_None, VT_None, 6, 32, IT_XOR)
+INSTR1_MI(0x81, PS_66, RT_GG, VT_16, VT_16, 7, 16, IT_CMP)
+INSTR1_MI(0x81, PS_None, RT_GG, VT_None, VT_None, 7, 32, IT_CMP)
+INSTR1_MI(0x83, PS_66, RT_GG, VT_16, VT_16, 0, 8, IT_ADD)
+INSTR1_MI(0x83, PS_None, RT_GG, VT_None, VT_None, 0, 8, IT_ADD)
+INSTR1_MI(0x83, PS_66, RT_GG, VT_16, VT_16, 1, 8, IT_OR)
+INSTR1_MI(0x83, PS_None, RT_GG, VT_None, VT_None, 1, 8, IT_OR)
+INSTR1_MI(0x83, PS_66, RT_GG, VT_16, VT_16, 2, 8, IT_ADC)
+INSTR1_MI(0x83, PS_None, RT_GG, VT_None, VT_None, 2, 8, IT_ADC)
+INSTR1_MI(0x83, PS_66, RT_GG, VT_16, VT_16, 3, 8, IT_SBB)
+INSTR1_MI(0x83, PS_None, RT_GG, VT_None, VT_None, 3, 8, IT_SBB)
+INSTR1_MI(0x83, PS_66, RT_GG, VT_16, VT_16, 4, 8, IT_AND)
+INSTR1_MI(0x83, PS_None, RT_GG, VT_None, VT_None, 4, 8, IT_AND)
+INSTR1_MI(0x83, PS_66, RT_GG, VT_16, VT_16, 5, 8, IT_SUB)
+INSTR1_MI(0x83, PS_None, RT_GG, VT_None, VT_None, 5, 8, IT_SUB)
+INSTR1_MI(0x83, PS_66, RT_GG, VT_16, VT_16, 6, 8, IT_XOR)
+INSTR1_MI(0x83, PS_None, RT_GG, VT_None, VT_None, 6, 8, IT_XOR)
+INSTR1_MI(0x83, PS_66, RT_GG, VT_16, VT_16, 7, 8, IT_CMP)
+INSTR1_MI(0x83, PS_None, RT_GG, VT_None, VT_None, 7, 8, IT_CMP)
+
+INSTR1_MR(0x84, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_TEST)
+INSTR1_MR(0x85, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_TEST)
+INSTR1_MR(0x85, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_TEST)
+INSTR1_MR(0x88, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_MOV)
+INSTR1_MR(0x89, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_MOV)
+INSTR1_MR(0x89, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_MOV)
+INSTR1_RM(0x8A, PS_None, RT_GG, VT_8, VT_8, VT_8, IT_MOV)
+INSTR1_RM(0x8B, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_MOV)
+INSTR1_RM(0x8B, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_MOV)
+INSTR1_RM(0x8D, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_LEA)
+INSTR1_RM(0x8D, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_LEA)
+INSTR1_M (0x8F, PS_66, RT_GG, VT_16, VT_16, 0, IT_POP)
+INSTR1_M (0x8F, PS_None, RT_GG, VT_64, VT_64, 0, IT_POP)
+// INSTR1_fn(0x90, PS_None, decode_nop_simple)
+INSTR1_NP(0x90, PS_None, VT_None, IT_NOP)
+INSTR1_NP(0x98, PS_None, VT_Implicit, IT_CLTQ)
+INSTR1_NP(0x99, PS_None, VT_Implicit, IT_CQTO)
+
+INSTR1_IA(0xA8, PS_None, VT_8, 8, IT_TEST)
+INSTR1_IA(0xA9, PS_66, VT_16, 16, IT_TEST)
+INSTR1_IA(0xA9, PS_None, VT_None, 32, IT_TEST)
+
+INSTR1_OI(0xB0, PS_None, VT_8, 8, IT_MOV)
+INSTR1_OI(0xB8, PS_66, VT_16, 16, IT_MOV)
+INSTR1_OI(0xB8, PS_None, VT_None, 0, IT_MOV)
+
+// Shift Group 2, Intel Vol. 2C A-19
+INSTR1_MI(0xC0, PS_None, RT_GG, VT_8, VT_8, 4, 8, IT_SHL)
+INSTR1_MI(0xC1, PS_66, RT_GG, VT_16, VT_16, 4, 8, IT_SHL)
+INSTR1_MI(0xC1, PS_None, RT_GG, VT_None, VT_None, 4, 8, IT_SHL)
+INSTR1_MI(0xC0, PS_None, RT_GG, VT_8, VT_8, 5, 8, IT_SHR)
+INSTR1_MI(0xC1, PS_66, RT_GG, VT_16, VT_16, 5, 8, IT_SHR)
+INSTR1_MI(0xC1, PS_None, RT_GG, VT_None, VT_None, 5, 8, IT_SHR)
+INSTR1_MI(0xC0, PS_None, RT_GG, VT_8, VT_8, 7, 8, IT_SAR)
+INSTR1_MI(0xC1, PS_66, RT_GG, VT_16, VT_16, 7, 8, IT_SAR)
+INSTR1_MI(0xC1, PS_None, RT_GG, VT_None, VT_None, 7, 8, IT_SAR)
+
+INSTR1_NP(0xC3, PS_None, VT_None, IT_RET)
+INSTR1_NP(0xC3, PS_F3, VT_None, IT_RET)
+INSTR1_MI(0xC6, PS_None, RT_GG, VT_8, VT_8, 0, 8, IT_MOV)
+INSTR1_MI(0xC7, PS_66, RT_GG, VT_16, VT_16, 0, 16, IT_MOV)
+INSTR1_MI(0xC7, PS_None, RT_GG, VT_None, VT_None, 0, 32, IT_MOV)
+INSTR1_NP(0xC9, PS_66, VT_16, IT_LEAVE)
+INSTR1_NP(0xC9, PS_None, VT_None, IT_LEAVE)
+
+// Shift Group 2, Intel Vol. 2C A-19
+INSTR1_M1(0xD0, PS_None, RT_GG, VT_8, VT_8, 4, IT_SHL)
+INSTR1_M1(0xD1, PS_66, RT_GG, VT_16, VT_16, 4, IT_SHL)
+INSTR1_M1(0xD1, PS_None, RT_GG, VT_None, VT_None, 4, IT_SHL)
+INSTR1_MC(0xD2, PS_None, RT_GG, VT_8, VT_8, 4, IT_SHL)
+INSTR1_MC(0xD3, PS_66, RT_GG, VT_16, VT_16, 4, IT_SHL)
+INSTR1_MC(0xD3, PS_None, RT_GG, VT_None, VT_None, 4, IT_SHL)
+INSTR1_M1(0xD0, PS_None, RT_GG, VT_8, VT_8, 5, IT_SHR)
+INSTR1_M1(0xD1, PS_66, RT_GG, VT_16, VT_16, 5, IT_SHR)
+INSTR1_M1(0xD1, PS_None, RT_GG, VT_None, VT_None, 5, IT_SHR)
+INSTR1_MC(0xD2, PS_None, RT_GG, VT_8, VT_8, 5, IT_SHR)
+INSTR1_MC(0xD3, PS_66, RT_GG, VT_16, VT_16, 5, IT_SHR)
+INSTR1_MC(0xD3, PS_None, RT_GG, VT_None, VT_None, 5, IT_SHR)
+INSTR1_M1(0xD0, PS_None, RT_GG, VT_8, VT_8, 7, IT_SAR)
+INSTR1_M1(0xD1, PS_66, RT_GG, VT_16, VT_16, 7, IT_SAR)
+INSTR1_M1(0xD1, PS_None, RT_GG, VT_None, VT_None, 7, IT_SAR)
+INSTR1_MC(0xD2, PS_None, RT_GG, VT_8, VT_8, 7, IT_SAR)
+INSTR1_MC(0xD3, PS_66, RT_GG, VT_16, VT_16, 7, IT_SAR)
+INSTR1_MC(0xD3, PS_None, RT_GG, VT_None, VT_None, 7, IT_SAR)
+
+INSTR1_D (0xE8, PS_None, VT_32, 32, IT_CALL)
+INSTR1_D (0xE9, PS_None, VT_32, 32, IT_JMP)
+INSTR1_D (0xEB, PS_None, VT_8, 8, IT_JMP)
+INSTR1_MI(0xF6, PS_None, RT_GG, VT_8, VT_8, 0, 8, IT_TEST)
+INSTR1_M (0xF6, PS_None, RT_GG, VT_8, VT_8, 2, IT_NOT)
+INSTR1_M (0xF6, PS_None, RT_GG, VT_8, VT_8, 3, IT_NEG)
+INSTR1_M (0xF6, PS_None, RT_GG, VT_8, VT_8, 4, IT_MUL)
+INSTR1_M (0xF6, PS_None, RT_GG, VT_8, VT_8, 5, IT_IMUL)
+INSTR1_M (0xF6, PS_None, RT_GG, VT_8, VT_8, 6, IT_DIV)
+INSTR1_M (0xF6, PS_None, RT_GG, VT_8, VT_8, 7, IT_IDIV1)
+INSTR1_MI(0xF7, PS_66, RT_GG, VT_16, VT_16, 0, 16, IT_TEST)
+INSTR1_MI(0xF7, PS_None, RT_GG, VT_Implicit, VT_None, 0, 32, IT_TEST)
+INSTR1_M (0xF7, PS_66, RT_GG, VT_16, VT_16, 2, IT_NOT)
+INSTR1_M (0xF7, PS_None, RT_GG, VT_Implicit, VT_None, 2, IT_NOT)
+INSTR1_M (0xF7, PS_66, RT_GG, VT_16, VT_16, 3, IT_NEG)
+INSTR1_M (0xF7, PS_None, RT_GG, VT_Implicit, VT_None, 3, IT_NEG)
+INSTR1_M (0xF7, PS_66, RT_GG, VT_16, VT_16, 4, IT_MUL)
+INSTR1_M (0xF7, PS_None, RT_GG, VT_Implicit, VT_None, 4, IT_MUL)
+INSTR1_M (0xF7, PS_66, RT_GG, VT_16, VT_16, 5, IT_IMUL)
+INSTR1_M (0xF7, PS_None, RT_GG, VT_Implicit, VT_None, 5, IT_IMUL)
+INSTR1_M (0xF7, PS_66, RT_GG, VT_16, VT_16, 6, IT_DIV)
+INSTR1_M (0xF7, PS_None, RT_GG, VT_Implicit, VT_None, 6, IT_DIV)
+INSTR1_M (0xF7, PS_66, RT_GG, VT_16, VT_16, 7, IT_IDIV1)
+INSTR1_M (0xF7, PS_None, RT_GG, VT_Implicit, VT_None, 7, IT_IDIV1)
+
+INSTR1_M (0xFE, PS_None, RT_GG, VT_8, VT_8, 0, IT_INC)
+INSTR1_M (0xFE, PS_None, RT_GG, VT_8, VT_8, 1, IT_DEC)
+INSTR1_M (0xFF, PS_None, RT_GG, VT_Implicit, VT_None, 0, IT_INC)
+INSTR1_M (0xFF, PS_66, RT_GG, VT_16, VT_16, 0, IT_INC)
+INSTR1_M (0xFF, PS_None, RT_GG, VT_Implicit, VT_None, 1, IT_DEC)
+INSTR1_M (0xFF, PS_66, RT_GG, VT_16, VT_16, 1, IT_DEC)
+INSTR1_M (0xFF, PS_None, RT_GG, VT_64, VT_64, 2, IT_CALL)
+INSTR1_M (0xFF, PS_None, RT_GG, VT_64, VT_64, 4, IT_JMPI)
+INSTR1_M (0xFF, PS_66, RT_GG, VT_16, VT_16, 6, IT_PUSH)
+INSTR1_M (0xFF, PS_None, RT_GG, VT_64, VT_64, 6, IT_PUSH)
+
+INSTR2_M (0x1F, PS_None, RT_VV, VT_None, VT_None, 0, IT_NOP)
+INSTR2_M (0x1F, PS_66, RT_VV, VT_16, VT_16, 0, IT_NOP)
+INSTR2_RMcc(0x40, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_CMOVO)
+INSTR2_RMcc(0x40, PS_None, RT_GG, VT_None, VT_None, VT_None, IT_CMOVO)
+INSTR2_Dcc(0x80, PS_None, VT_32, 32, IT_JO)
+INSTR2_Mcc(0x90, PS_None, RT_GG, VT_8, VT_Implicit, -1, IT_SETO)
+INSTR2_RM(0xAF, PS_66, RT_GG, VT_16, VT_16, VT_Implicit, IT_IMUL)
+INSTR2_RM(0xAF, PS_None, RT_GG, VT_None, VT_None, VT_Implicit, IT_IMUL)
+INSTR2_RM(0xB6, PS_66, RT_GG, VT_16, VT_8, VT_16, IT_MOVZX)
+INSTR2_RM(0xB6, PS_None, RT_GG, VT_None, VT_8, VT_None, IT_MOVZX)
+INSTR2_RM(0xB7, PS_None, RT_GG, VT_None, VT_16, VT_None, IT_MOVZX)
+INSTR2_RM(0xBC, PS_66, RT_GG, VT_16, VT_16, VT_16, IT_BSF)
+INSTR2_RM(0xBC, PS_None, RT_GG, VT_None, VT_None, VT_Implicit, IT_BSF)
+INSTR2_RM(0xBE, PS_66, RT_GG, VT_16, VT_8, VT_16, IT_MOVSX)
+INSTR2_RM(0xBE, PS_None, RT_GG, VT_None, VT_8, VT_None, IT_MOVSX)
+INSTR2_RM(0xBF, PS_None, RT_GG, VT_None, VT_16, VT_None, IT_MOVSX)
+
+// SSE Instructions
+INSTR2_RM(0x10, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_MOVSS)
+INSTR2_RM(0x10, PS_F2, RT_VV, VT_64, VT_64, VT_Implicit, IT_MOVSD)
+INSTR2_RM(0x10, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVUPS)
+INSTR2_RM(0x10, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVUPD)
+INSTR2_MR(0x11, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_MOVSS)
+INSTR2_MR(0x11, PS_F2, RT_VV, VT_64, VT_64, VT_Implicit, IT_MOVSD)
+INSTR2_MR(0x11, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVUPS)
+INSTR2_MR(0x11, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVUPD)
+INSTR2_RM(0x12, PS_None, RT_VV, VT_64, VT_64, VT_Implicit, IT_MOVLPS)
+INSTR2_RM(0x12, PS_66, RT_VV, VT_64, VT_64, VT_Implicit, IT_MOVLPD)
+INSTR2_MR(0x13, PS_None, RT_VV, VT_64, VT_64, VT_Implicit, IT_MOVLPS)
+INSTR2_MR(0x13, PS_66, RT_VV, VT_64, VT_64, VT_Implicit, IT_MOVLPD)
+INSTR2_RM(0x14, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_UNPCKLPS)
+INSTR2_RM(0x14, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_UNPCKLPD)
+INSTR2_RM(0x15, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_UNPCKHPS)
+INSTR2_RM(0x15, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_UNPCKHPD)
+INSTR2_RM(0x16, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVHPS)
+INSTR2_RM(0x16, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVHPD)
+INSTR2_MR(0x17, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVHPS)
+INSTR2_MR(0x17, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVHPD)
+INSTR2_RM(0x28, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVAPS)
+INSTR2_RM(0x28, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVAPD)
+INSTR2_MR(0x29, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVAPS)
+INSTR2_MR(0x29, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVAPD)
+INSTR2_MR(0x2E, PS_None, RT_VV, VT_32, VT_32, VT_Implicit, IT_UCOMISS)
+INSTR2_MR(0x2E, PS_66, RT_VV, VT_64, VT_64, VT_Implicit, IT_UCOMISD)
+INSTR2_MR(0x2F, PS_None, RT_VV, VT_32, VT_32, VT_Implicit, IT_COMISS)
+INSTR2_MR(0x2F, PS_66, RT_VV, VT_64, VT_64, VT_Implicit, IT_COMISD)
+INSTR2_RM(0x51, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_SQRTSS)
+INSTR2_RM(0x51, PS_F2, RT_VV, VT_64, VT_64, VT_Implicit, IT_SQRTSD)
+INSTR2_RM(0x51, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_SQRTPS)
+INSTR2_RM(0x51, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_SQRTPD)
+INSTR2_RM(0x52, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_RSQRTSS)
+INSTR2_RM(0x52, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_RSQRTPS)
+INSTR2_RM(0x53, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_RCPSS)
+INSTR2_RM(0x53, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_RCPPS)
+INSTR2_RM(0x54, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_ANDPS)
+INSTR2_RM(0x54, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_ANDPD)
+INSTR2_RM(0x55, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_ANDNPS)
+INSTR2_RM(0x55, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_ANDNPD)
+INSTR2_RM(0x56, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_ORPS)
+INSTR2_RM(0x56, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_ORPD)
+INSTR2_RM(0x57, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_XORPS)
+INSTR2_RM(0x57, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_XORPD)
+INSTR2_RM(0x58, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_ADDSS)
+INSTR2_RM(0x58, PS_F2, RT_VV, VT_64, VT_64, VT_Implicit, IT_ADDSD)
+INSTR2_RM(0x58, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_ADDPS)
+INSTR2_RM(0x58, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_ADDPD)
+INSTR2_RM(0x59, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_MULSS)
+INSTR2_RM(0x59, PS_F2, RT_VV, VT_64, VT_64, VT_Implicit, IT_MULSD)
+INSTR2_RM(0x59, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_MULPS)
+INSTR2_RM(0x59, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MULPD)
+INSTR2_RM(0x5C, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_SUBSS)
+INSTR2_RM(0x5C, PS_F2, RT_VV, VT_64, VT_64, VT_Implicit, IT_SUBSD)
+INSTR2_RM(0x5C, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_SUBPS)
+INSTR2_RM(0x5C, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_SUBPD)
+INSTR2_RM(0x5D, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_MINSS)
+INSTR2_RM(0x5D, PS_F2, RT_VV, VT_64, VT_64, VT_Implicit, IT_MINSD)
+INSTR2_RM(0x5D, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_MINPS)
+INSTR2_RM(0x5D, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MINPD)
+INSTR2_RM(0x5E, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_DIVSS)
+INSTR2_RM(0x5E, PS_F2, RT_VV, VT_64, VT_64, VT_Implicit, IT_DIVSD)
+INSTR2_RM(0x5E, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_DIVPS)
+INSTR2_RM(0x5E, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_DIVPD)
+INSTR2_RM(0x5F, PS_F3, RT_VV, VT_32, VT_32, VT_Implicit, IT_MAXSS)
+INSTR2_RM(0x5F, PS_F2, RT_VV, VT_64, VT_64, VT_Implicit, IT_MAXSD)
+INSTR2_RM(0x5F, PS_None, RT_VV, VT_128, VT_128, VT_Implicit, IT_MAXPS)
+INSTR2_RM(0x5F, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MAXPD)
+INSTR2_RM(0x6E, PS_66, RT_VG, VT_None, VT_None, VT_None, IT_MOVQ)
+INSTR2_RM(0x6F, PS_F3, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVDQU)
+INSTR2_RM(0x6F, PS_None, RT_VV, VT_64, VT_64, VT_Implicit, IT_MOVQ)
+INSTR2_RM(0x6F, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVDQA)
+INSTR2_RM(0x74, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_PCMPEQB)
+INSTR2_RM(0x75, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_PCMPEQW)
+INSTR2_RM(0x76, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_PCMPEQD)
+INSTR2_RM(0x7C, PS_F2, RT_VV, VT_128, VT_128, VT_Implicit, IT_HADDPS)
+INSTR2_RM(0x7C, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_HADDPD)
+INSTR2_RM(0x7D, PS_F2, RT_VV, VT_128, VT_128, VT_Implicit, IT_HSUBPS)
+INSTR2_RM(0x7D, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_HSUBPD)
+INSTR2_RM(0x7E, PS_F3, RT_VV, VT_64, VT_64, VT_Implicit, IT_MOVQ)
+INSTR2_MR(0x7E, PS_66, RT_GV, VT_None, VT_None, VT_None, IT_MOVQ)
+INSTR2_MR(0x7F, PS_F3, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVDQU)
+INSTR2_MR(0x7F, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_MOVDQA)
+INSTR2_RM(0xD0, PS_F2, RT_VV, VT_128, VT_128, VT_Implicit, IT_ADDSUBPS)
+INSTR2_RM(0xD0, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_ADDSUBPD)
+INSTR2_RM(0xD4, PS_None, RT_VV, VT_64, VT_64, VT_Implicit, IT_PADDQ)
+INSTR2_RM(0xD4, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_PADDQ)
+INSTR2_MR(0xD6, PS_66, RT_VV, VT_64, VT_64, VT_Implicit, IT_MOVQ)
+INSTR2_RM(0xDA, PS_None, RT_VV, VT_64, VT_64, VT_Implicit, IT_PMINUB)
+INSTR2_RM(0xDA, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_PMINUB)
+INSTR2_RM(0xEF, PS_None, RT_VV, VT_64, VT_64, VT_Implicit, IT_PXOR)
+INSTR2_RM(0xEF, PS_66, RT_VV, VT_128, VT_128, VT_Implicit, IT_PXOR)
+
+// Terminator
+{ OE_Invalid, 0, {0, 0, 0}, 0, RT_GG, 0, 0, 0, -1, 0, false, IT_Invalid, NULL }
+};

--- a/src/instr.c
+++ b/src/instr.c
@@ -385,7 +385,6 @@ void copyInstr(Instr* dst, Instr* src)
     if (src->ptLen > 0) {
         dst->ptPSet = src->ptPSet;
         dst->ptEnc  = src->ptEnc;
-        dst->ptSChange = src->ptSChange;
         for(int j=0; j < src->ptLen; j++)
             dst->ptOpc[j] = src->ptOpc[j];
     }
@@ -417,12 +416,12 @@ void initUnaryInstr(Instr* i, InstrType it, Operand* o)
 void initBinaryInstr(Instr* i, InstrType it, ValType vt,
                      Operand *o1, Operand *o2)
 {
-    if (vt != VT_None) {
+    if (vt != VT_None && vt != VT_Implicit) {
         // if we specify a value type, it must match destination
         assert(vt == opValType(o1));
         // if 2nd operand is other than immediate, types also must match
-        if (!opIsImm(o2))
-            assert(vt == opValType(o2));
+        // if (!opIsImm(o2) && it != IT_MOVSX)
+        //     assert(vt == opValType(o2));
     }
 
     initSimpleInstr(i, it);
@@ -443,13 +442,11 @@ void initTernaryInstr(Instr* i, InstrType it,
 }
 
 
-void attachPassthrough(Instr* i, PrefixSet set,
-                       OperandEncoding enc, StateChange sc,
-                       int b1, int b2, int b3)
+void
+attachPassthrough(Instr* i, PrefixSet set, OperandEncoding enc, int b1, int b2, int b3)
 {
     assert(i->ptLen == 0);
     i->ptEnc = enc;
-    i->ptSChange = sc;
     i->ptPSet = set;
     assert(b1 >= 0);
     i->ptLen++;

--- a/src/printer.c
+++ b/src/printer.c
@@ -274,9 +274,12 @@ char* op2string(Operand* o, ValType t, FunctionConfig* fc)
         assert(val < (1l<<8));
         switch(t) {
         case VT_None:
+        case VT_Implicit:
         case VT_8:
             break;
         case VT_16:
+            if (val > 0x7F) val += 0xFF00;
+            break;
         case VT_32:
             if (val > 0x7F) val += 0xFFFFFF00;
             break;
@@ -298,6 +301,7 @@ char* op2string(Operand* o, ValType t, FunctionConfig* fc)
         case VT_64:
             if (val > 0x7FFF) val += 0xFFFFFFFFFFFF0000;
             break;
+        case VT_8:
         case VT_16:
         case VT_None:
             break;
@@ -455,7 +459,6 @@ const char* instrName(InstrType it, int* pOpCount)
     case IT_MOVLPS:  n = "movlps";  opCount = 2; break;
     case IT_MOVHPD:  n = "movhpd";  opCount = 2; break;
     case IT_MOVHPS:  n = "movhps";  opCount = 2; break;
-
     case IT_ADDSS:   n = "addss";   opCount = 2; break;
     case IT_ADDSD:   n = "addsd";   opCount = 2; break;
     case IT_ADDPS:   n = "addps";   opCount = 2; break;

--- a/tests/cases/decode/it-leave.s
+++ b/tests/cases/decode/it-leave.s
@@ -7,6 +7,6 @@
 f1:
     // LEAVE instructions, Intel Vol. 2A 3-483
     leave
-    // leavew // no need to implement 16-bit address-mode
+    leavew
 
     ret

--- a/tests/cases/decode/it-leave.s.expect
+++ b/tests/cases/decode/it-leave.s.expect
@@ -1,3 +1,4 @@
-BB f1 (2 instructions):
+BB f1 (3 instructions):
                   f1:  c9                    leave  
-                f1+1:  c3                    ret    
+                f1+1:  66 c9                 leavew 
+                f1+3:  c3                    ret    

--- a/tests/cases/decode/it-shift.s.expect
+++ b/tests/cases/decode/it-shift.s.expect
@@ -1,106 +1,106 @@
 BB f1 (109 instructions):
-                  f1:  d0 e0                 shl     %al
-                f1+2:  41 d0 e2              shl     %r10b
-                f1+5:  d0 20                 shlb    (%rax)
+                  f1:  d0 e0                 shl     $0x1,%al
+                f1+2:  41 d0 e2              shl     $0x1,%r10b
+                f1+5:  d0 20                 shlb    $0x1,(%rax)
                 f1+7:  d2 e0                 shl     %cl,%al
                 f1+9:  41 d2 e2              shl     %cl,%r10b
                f1+12:  d2 20                 shl     %cl,(%rax)
                f1+14:  c0 e0 05              shl     $0x5,%al
                f1+17:  41 c0 e2 05           shl     $0x5,%r10b
                f1+21:  c0 20 05              shlb    $0x5,(%rax)
-               f1+24:  66 d1 e0              shl     %ax
-               f1+27:  66 41 d1 e2           shl     %r10w
-               f1+31:  66 d1 20              shlw    (%rax)
+               f1+24:  66 d1 e0              shl     $0x1,%ax
+               f1+27:  66 41 d1 e2           shl     $0x1,%r10w
+               f1+31:  66 d1 20              shlw    $0x1,(%rax)
                f1+34:  66 d3 e0              shl     %cl,%ax
                f1+37:  66 41 d3 e2           shl     %cl,%r10w
                f1+41:  66 d3 20              shl     %cl,(%rax)
                f1+44:  66 c1 e0 05           shl     $0x5,%ax
                f1+48:  66 41 c1 e2 05        shl     $0x5,%r10w
                f1+53:  66 c1 20 05           shlw    $0x5,(%rax)
-               f1+57:  d1 e0                 shl     %eax
-               f1+59:  41 d1 e2              shl     %r10d
-               f1+62:  d1 20                 shll    (%rax)
+               f1+57:  d1 e0                 shl     $0x1,%eax
+               f1+59:  41 d1 e2              shl     $0x1,%r10d
+               f1+62:  d1 20                 shll    $0x1,(%rax)
                f1+64:  d3 e0                 shl     %cl,%eax
                f1+66:  41 d3 e2              shl     %cl,%r10d
                f1+69:  d3 20                 shl     %cl,(%rax)
                f1+71:  c1 e0 05              shl     $0x5,%eax
                f1+74:  41 c1 e2 05           shl     $0x5,%r10d
                f1+78:  c1 20 05              shll    $0x5,(%rax)
-               f1+81:  48 d1 e0              shl     %rax
-               f1+84:  49 d1 e2              shl     %r10
-               f1+87:  48 d1 20              shlq    (%rax)
+               f1+81:  48 d1 e0              shl     $0x1,%rax
+               f1+84:  49 d1 e2              shl     $0x1,%r10
+               f1+87:  48 d1 20              shlq    $0x1,(%rax)
                f1+90:  48 d3 e0              shl     %cl,%rax
                f1+93:  49 d3 e2              shl     %cl,%r10
                f1+96:  48 d3 20              shl     %cl,(%rax)
                f1+99:  48 c1 e0 05           shl     $0x5,%rax
               f1+103:  49 c1 e2 05           shl     $0x5,%r10
               f1+107:  48 c1 20 05           shlq    $0x5,(%rax)
-              f1+111:  d0 e8                 shr     %al
-              f1+113:  41 d0 ea              shr     %r10b
-              f1+116:  d0 28                 shrb    (%rax)
+              f1+111:  d0 e8                 shr     $0x1,%al
+              f1+113:  41 d0 ea              shr     $0x1,%r10b
+              f1+116:  d0 28                 shrb    $0x1,(%rax)
               f1+118:  d2 e8                 shr     %cl,%al
               f1+120:  41 d2 ea              shr     %cl,%r10b
               f1+123:  d2 28                 shr     %cl,(%rax)
               f1+125:  c0 e8 05              shr     $0x5,%al
               f1+128:  41 c0 ea 05           shr     $0x5,%r10b
               f1+132:  c0 28 05              shrb    $0x5,(%rax)
-              f1+135:  66 d1 e8              shr     %ax
-              f1+138:  66 41 d1 ea           shr     %r10w
-              f1+142:  66 d1 28              shrw    (%rax)
+              f1+135:  66 d1 e8              shr     $0x1,%ax
+              f1+138:  66 41 d1 ea           shr     $0x1,%r10w
+              f1+142:  66 d1 28              shrw    $0x1,(%rax)
               f1+145:  66 d3 e8              shr     %cl,%ax
               f1+148:  66 41 d3 ea           shr     %cl,%r10w
               f1+152:  66 d3 28              shr     %cl,(%rax)
               f1+155:  66 c1 e8 05           shr     $0x5,%ax
               f1+159:  66 41 c1 ea 05        shr     $0x5,%r10w
               f1+164:  66 c1 28 05           shrw    $0x5,(%rax)
-              f1+168:  d1 e8                 shr     %eax
-              f1+170:  41 d1 ea              shr     %r10d
-              f1+173:  d1 28                 shrl    (%rax)
+              f1+168:  d1 e8                 shr     $0x1,%eax
+              f1+170:  41 d1 ea              shr     $0x1,%r10d
+              f1+173:  d1 28                 shrl    $0x1,(%rax)
               f1+175:  d3 e8                 shr     %cl,%eax
               f1+177:  41 d3 ea              shr     %cl,%r10d
               f1+180:  d3 28                 shr     %cl,(%rax)
               f1+182:  c1 e8 05              shr     $0x5,%eax
               f1+185:  41 c1 ea 05           shr     $0x5,%r10d
               f1+189:  c1 28 05              shrl    $0x5,(%rax)
-              f1+192:  48 d1 e8              shr     %rax
-              f1+195:  49 d1 ea              shr     %r10
-              f1+198:  48 d1 28              shrq    (%rax)
+              f1+192:  48 d1 e8              shr     $0x1,%rax
+              f1+195:  49 d1 ea              shr     $0x1,%r10
+              f1+198:  48 d1 28              shrq    $0x1,(%rax)
               f1+201:  48 d3 e8              shr     %cl,%rax
               f1+204:  49 d3 ea              shr     %cl,%r10
               f1+207:  48 d3 28              shr     %cl,(%rax)
               f1+210:  48 c1 e8 05           shr     $0x5,%rax
               f1+214:  49 c1 ea 05           shr     $0x5,%r10
               f1+218:  48 c1 28 05           shrq    $0x5,(%rax)
-              f1+222:  d0 f8                 sar     %al
-              f1+224:  41 d0 fa              sar     %r10b
-              f1+227:  d0 38                 sarb    (%rax)
+              f1+222:  d0 f8                 sar     $0x1,%al
+              f1+224:  41 d0 fa              sar     $0x1,%r10b
+              f1+227:  d0 38                 sarb    $0x1,(%rax)
               f1+229:  d2 f8                 sar     %cl,%al
               f1+231:  41 d2 fa              sar     %cl,%r10b
               f1+234:  d2 38                 sar     %cl,(%rax)
               f1+236:  c0 f8 05              sar     $0x5,%al
               f1+239:  41 c0 fa 05           sar     $0x5,%r10b
               f1+243:  c0 38 05              sarb    $0x5,(%rax)
-              f1+246:  66 d1 f8              sar     %ax
-              f1+249:  66 41 d1 fa           sar     %r10w
-              f1+253:  66 d1 38              sarw    (%rax)
+              f1+246:  66 d1 f8              sar     $0x1,%ax
+              f1+249:  66 41 d1 fa           sar     $0x1,%r10w
+              f1+253:  66 d1 38              sarw    $0x1,(%rax)
               f1+256:  66 d3 f8              sar     %cl,%ax
               f1+259:  66 41 d3 fa           sar     %cl,%r10w
               f1+263:  66 d3 38              sar     %cl,(%rax)
               f1+266:  66 c1 f8 05           sar     $0x5,%ax
               f1+270:  66 41 c1 fa 05        sar     $0x5,%r10w
               f1+275:  66 c1 38 05           sarw    $0x5,(%rax)
-              f1+279:  d1 f8                 sar     %eax
-              f1+281:  41 d1 fa              sar     %r10d
-              f1+284:  d1 38                 sarl    (%rax)
+              f1+279:  d1 f8                 sar     $0x1,%eax
+              f1+281:  41 d1 fa              sar     $0x1,%r10d
+              f1+284:  d1 38                 sarl    $0x1,(%rax)
               f1+286:  d3 f8                 sar     %cl,%eax
               f1+288:  41 d3 fa              sar     %cl,%r10d
               f1+291:  d3 38                 sar     %cl,(%rax)
               f1+293:  c1 f8 05              sar     $0x5,%eax
               f1+296:  41 c1 fa 05           sar     $0x5,%r10d
               f1+300:  c1 38 05              sarl    $0x5,(%rax)
-              f1+303:  48 d1 f8              sar     %rax
-              f1+306:  49 d1 fa              sar     %r10
-              f1+309:  48 d1 38              sarq    (%rax)
+              f1+303:  48 d1 f8              sar     $0x1,%rax
+              f1+306:  49 d1 fa              sar     $0x1,%r10
+              f1+309:  48 d1 38              sarq    $0x1,(%rax)
               f1+312:  48 d3 f8              sar     %cl,%rax
               f1+315:  49 d3 fa              sar     %cl,%r10
               f1+318:  48 d3 38              sar     %cl,(%rax)

--- a/tests/cases/decode/sse.s.expect
+++ b/tests/cases/decode/sse.s.expect
@@ -27,8 +27,8 @@ BB f1 (49 instructions):
               f1+103:  f3 0f 7f 02           movdqu  %xmm0,(%rdx)
               f1+107:  66 0f 6f 02           movdqa  (%rdx),%xmm0
               f1+111:  66 0f 7f 02           movdqa  %xmm0,(%rdx)
-              f1+115:  66 0f 6e 02           movd    (%rdx),%xmm0
-              f1+119:  66 0f 7e 02           movd    %xmm0,(%rdx)
+              f1+115:  66 0f 6e 02           movql   (%rdx),%xmm0
+              f1+119:  66 0f 7e 02           movql   %xmm0,(%rdx)
               f1+123:  66 44 0f 13 16        movlpd  %xmm10,(%rsi)
               f1+128:  66 0f 12 07           movlpd  (%rdi),%xmm0
               f1+132:  44 0f 13 16           movlps  %xmm10,(%rsi)

--- a/tests/test-driver-decode.c
+++ b/tests/test-driver-decode.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 
 #include "dbrew.h"
+#include "priv/common.h"
 
 int f1(int);
 // possible jump target
@@ -18,7 +19,10 @@ int main()
     // to get rid of changing addresses, assume gen code to be 800 bytes max
     dbrew_config_function_setname(r, (uintptr_t) f1, "f1");
     dbrew_config_function_setsize(r, (uintptr_t) f1, 800);
-    dbrew_decode_print(r, (uintptr_t) f1, 1);
+
+    DBB* dbb = dbrew_decode(r, (uintptr_t) f1);
+    printf("BB f1 (%d instructions):\n", dbb->count);
+    dbrew_print_decoded(dbb);
 
     return 0;
 }


### PR DESCRIPTION
Implementation of a new decoding structure which makes it much easier to add new instructions and therefore to maintain while removing many lines of code. Each instruction is now only a descriptor specifying the instruction type, the opcodes, the operand types and the encoding. The descriptors are in a separate file to allow usage in other places, e.g. the generator. Many common instructions are supported in all variants and properly tested.

**Update:** Now, also custom decoding handlers are supported.