### PR TITLE
Fix use-after-free when freeing a rewriter

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -146,9 +146,9 @@ void freeRewriter(Rewriter* r)
     freeEmuState(r);
     if (r->cs)
         freeCodeStorage(r->cs);
-    free(r);
-
     expr_freePool(r->ePool);
+
+    free(r);
 }
 
 


### PR DESCRIPTION
The expression pool was freed *after* the rewriter has been freed. This causes an abort when freeing a rewriter.