### PR TITLE
Fix decoding of r12 in ModRM SIB byte

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -308,6 +308,7 @@ void parseModRM(DContext* cxt, ValType vt, RegTypes rts,
         sib = cxt->f[cxt->off++];
         scale = 1 << ((sib & 192) >> 6);
         idx   = (sib & 56) >> 3;
+        if (cxt->rex & REX_MASK_X) idx += 8;
         base  = sib & 7;
         if ((base == 5) && (mod == 0))
             hasDisp32 = 1;
@@ -360,7 +361,6 @@ void parseModRM(DContext* cxt, ValType vt, RegTypes rts,
         o1->scale = 0; // index register not used: set scale to 0
     }
     else {
-        if (cxt->rex & REX_MASK_X) idx += 8;
         o1->ireg = getReg(RT_GP64, (RegIndex) idx);
     }
 

--- a/tests/cases/decode/modrm.s
+++ b/tests/cases/decode/modrm.s
@@ -108,5 +108,7 @@ f1:
     mov r9, qword ptr [r13]
     mov r9, qword ptr [r14]
 
+    lea r9, [r9 + 8 * r12 - 704]
+
     ret
 

--- a/tests/cases/decode/modrm.s.expect
+++ b/tests/cases/decode/modrm.s.expect
@@ -1,4 +1,4 @@
-BB f1 (99 instructions):
+BB f1 (100 instructions):
                   f1:  48 ff c0              inc     %rax
                 f1+3:  48 ff c5              inc     %rbp
                 f1+6:  49 ff c1              inc     %r9
@@ -123,4 +123,6 @@ BB f1 (99 instructions):
               f1+517:  4d 8b 0c 24           mov     (%r12),%r9
               f1+521:  4d 8b 4d 00           mov     (%r13),%r9
               f1+525:  4d 8b 0e              mov     (%r14),%r9
-              f1+528:  c3                    ret    
+              f1+528:  4f 8d 8c e1 40 fd ff  lea     -0x2c0(%r9,%r12,8),%r9
+              f1+535:  ff                  
+              f1+536:  c3                    ret    


### PR DESCRIPTION
When REX.X is set, a fourth bit is encoded in the scaled register index. This bit has to be respected when checking whether the index register has to be ignored. See Intel Vol. 2A 2-11, Table 2-5.