### PR TITLE
Fix decode test case for Clang

### DIFF
--- a/tests/cases/decode/it-mov.s
+++ b/tests/cases/decode/it-mov.s
@@ -28,8 +28,8 @@ f1:
     mov r10w, 0x1000
     mov edx, 0x10000000
     mov r10d, 0x10000000
-    mov rdx, 0x1000000000000000
-    mov r10, 0x1000000000000000
+    movabs rdx, 0x1000000000000000
+    movabs r10, 0x1000000000000000
     mov byte ptr [rdi], 0x10
     mov byte ptr [r10], 0x10
     mov word ptr [rdi], 0x1000


### PR DESCRIPTION
Sometimes, Clang complains if movabs is not used for moves with a 64-bit immediate. I don't know why it doesn't here in Travis.